### PR TITLE
ウィンドウ左側に動作するツリービューを追加

### DIFF
--- a/MusicPlayer/MainWindow.xaml
+++ b/MusicPlayer/MainWindow.xaml
@@ -5,6 +5,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:m="clr-namespace:MusicPlayer.model"
         xmlns:local="clr-namespace:MusicPlayer"
+        xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
         mc:Ignorable="d"
         Title="MainWindow" Height="446" Width="800">
 

--- a/MusicPlayer/MainWindow.xaml
+++ b/MusicPlayer/MainWindow.xaml
@@ -3,6 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:m="clr-namespace:MusicPlayer.model"
         xmlns:local="clr-namespace:MusicPlayer"
         mc:Ignorable="d"
         Title="MainWindow" Height="446" Width="800">
@@ -18,7 +19,13 @@
         </Grid.ColumnDefinitions>
 
         <TreeView Name="directoryTree"
+                  ItemsSource="{Binding Directory}"
                   Grid.Column="0" >
+            <TreeView.ItemTemplate>
+                <HierarchicalDataTemplate DataType="m:MediaDirectory"  ItemsSource="{Binding ChildDirectory}">
+                    <TextBlock Text="{Binding Name}" />
+                </HierarchicalDataTemplate>
+            </TreeView.ItemTemplate>
         </TreeView>
 
         <ListView Name="musicListView"

--- a/MusicPlayer/MainWindow.xaml
+++ b/MusicPlayer/MainWindow.xaml
@@ -22,9 +22,16 @@
         <TreeView Name="directoryTree"
                   ItemsSource="{Binding Directory}"
                   Grid.Column="0" >
+
             <TreeView.ItemTemplate>
                 <HierarchicalDataTemplate DataType="m:MediaDirectory"  ItemsSource="{Binding ChildDirectory}">
-                    <TextBlock Text="{Binding Name}" />
+                    <ContentControl Content="{Binding Name}">
+                        <i:Interaction.Triggers>
+                            <i:EventTrigger EventName="MouseDoubleClick">
+                                <i:InvokeCommandAction Command="{Binding GetChildsCommand}" />
+                            </i:EventTrigger>
+                        </i:Interaction.Triggers>
+                    </ContentControl>
                 </HierarchicalDataTemplate>
             </TreeView.ItemTemplate>
         </TreeView>

--- a/MusicPlayer/MainWindow.xaml
+++ b/MusicPlayer/MainWindow.xaml
@@ -7,6 +7,10 @@
         mc:Ignorable="d"
         Title="MainWindow" Height="446" Width="800">
 
+    <Window.DataContext>
+        <local:MainWindowViewModel />
+    </Window.DataContext>
+
     <Grid>
         <Grid.ColumnDefinitions>
             <ColumnDefinition/>

--- a/MusicPlayer/MainWindowViewModel.cs
+++ b/MusicPlayer/MainWindowViewModel.cs
@@ -1,14 +1,26 @@
 ﻿using MusicPlayer.model;
+using Prism.Mvvm;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
 namespace MusicPlayer {
-    class MainWindowViewModel {
+    class MainWindowViewModel : BindableBase{
 
-        public List<MediaDirectory> Directory { get; set; }
+        private List<MediaDirectory> directory = new List<MediaDirectory>();
+
+        public List<MediaDirectory> Directory {
+            get {
+                return directory;
+            }
+            private set {
+                SetProperty(ref directory, value);
+                directory = value;
+            }
+        }
 
     }
 }

--- a/MusicPlayer/MainWindowViewModel.cs
+++ b/MusicPlayer/MainWindowViewModel.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MusicPlayer {
+    class MainWindowViewModel {
+
+    }
+}

--- a/MusicPlayer/MainWindowViewModel.cs
+++ b/MusicPlayer/MainWindowViewModel.cs
@@ -22,5 +22,13 @@ namespace MusicPlayer {
             }
         }
 
+        public MainWindowViewModel() {
+            var baseDirectory = new MediaDirectory();
+            baseDirectory.FileInfo = new FileInfo(@"C:\Users");
+
+            var dir = new List<MediaDirectory>();
+            dir.Add(baseDirectory);
+            Directory = dir;
+        }
     }
 }

--- a/MusicPlayer/MainWindowViewModel.cs
+++ b/MusicPlayer/MainWindowViewModel.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using MusicPlayer.model;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -6,6 +7,8 @@ using System.Threading.Tasks;
 
 namespace MusicPlayer {
     class MainWindowViewModel {
+
+        public List<MediaDirectory> Directory { get; set; }
 
     }
 }

--- a/MusicPlayer/MusicPlayer.csproj
+++ b/MusicPlayer/MusicPlayer.csproj
@@ -35,6 +35,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Expression.Interactions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Windows.Interactivity.WPF.2.0.20525\lib\net40\Microsoft.Expression.Interactions.dll</HintPath>
+    </Reference>
     <Reference Include="Prism, Version=7.2.0.1422, Culture=neutral, PublicKeyToken=40ee6c3a2184dc59, processorArchitecture=MSIL">
       <HintPath>..\packages\Prism.Core.7.2.0.1422\lib\net45\Prism.dll</HintPath>
     </Reference>
@@ -42,6 +45,9 @@
     <Reference Include="System.Data" />
     <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Windows.Interactivity, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Windows.Interactivity.WPF.2.0.20525\lib\net40\System.Windows.Interactivity.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="Microsoft.CSharp" />
@@ -115,6 +121,9 @@
       <Isolated>False</Isolated>
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </COMReference>
+  </ItemGroup>
+  <ItemGroup>
+    <WCFMetadata Include="Connected Services\" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/MusicPlayer/MusicPlayer.csproj
+++ b/MusicPlayer/MusicPlayer.csproj
@@ -69,6 +69,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="MainWindowViewModel.cs" />
     <Compile Include="model\DoubleSoundPlayer.cs" />
     <Compile Include="model\SoundPlayer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs">

--- a/MusicPlayer/MusicPlayer.csproj
+++ b/MusicPlayer/MusicPlayer.csproj
@@ -35,8 +35,14 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Prism, Version=7.2.0.1422, Culture=neutral, PublicKeyToken=40ee6c3a2184dc59, processorArchitecture=MSIL">
+      <HintPath>..\packages\Prism.Core.7.2.0.1422\lib\net45\Prism.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Core" />
@@ -90,6 +96,7 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+    <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/MusicPlayer/MusicPlayer.csproj
+++ b/MusicPlayer/MusicPlayer.csproj
@@ -71,6 +71,7 @@
   <ItemGroup>
     <Compile Include="MainWindowViewModel.cs" />
     <Compile Include="model\DoubleSoundPlayer.cs" />
+    <Compile Include="model\MediaDirectory.cs" />
     <Compile Include="model\SoundPlayer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs">
       <SubType>Code</SubType>

--- a/MusicPlayer/model/MediaDirectory.cs
+++ b/MusicPlayer/model/MediaDirectory.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -7,8 +9,15 @@ using System.Threading.Tasks;
 namespace MusicPlayer.model {
     class MediaDirectory {
 
-        public String Name { get; set; }
+        public String Name {
+            get {
+                if (FileInfo == null) return "";
+                else return FileInfo.Name;
+            }
+        }
+
         public List<MediaDirectory> ChildDirectory { get; set; }
+        public FileInfo FileInfo { get; set; }
 
     }
 }

--- a/MusicPlayer/model/MediaDirectory.cs
+++ b/MusicPlayer/model/MediaDirectory.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Prism.Commands;
 
 namespace MusicPlayer.model {
     class MediaDirectory {
@@ -19,5 +20,23 @@ namespace MusicPlayer.model {
         public List<MediaDirectory> ChildDirectory { get; set; }
         public FileInfo FileInfo { get; set; }
 
+        public MediaDirectory() {
+            GetChildsCommand = new DelegateCommand(
+                () => { getChild(); },
+                () => { return true; }
+            );
+        }
+
+        private void getChild() {
+            ChildDirectory = new List<MediaDirectory>();
+            string[] childFileNames = System.IO.Directory.GetDirectories(FileInfo.FullName);
+            foreach (string n in childFileNames) {
+                var md = new MediaDirectory();
+                md.FileInfo = new FileInfo(n);
+                ChildDirectory.Add(md);
+            }
+        }
+
+        public DelegateCommand GetChildsCommand { get; private set; }
     }
 }

--- a/MusicPlayer/model/MediaDirectory.cs
+++ b/MusicPlayer/model/MediaDirectory.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MusicPlayer.model {
+    class MediaDirectory {
+
+        public String Name { get; set; }
+        public List<MediaDirectory> ChildDirectory { get; set; }
+
+    }
+}

--- a/MusicPlayer/model/MediaDirectory.cs
+++ b/MusicPlayer/model/MediaDirectory.cs
@@ -6,9 +6,10 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Prism.Commands;
+using Prism.Mvvm;
 
 namespace MusicPlayer.model {
-    class MediaDirectory {
+    class MediaDirectory : BindableBase{
 
         public String Name {
             get {
@@ -17,7 +18,16 @@ namespace MusicPlayer.model {
             }
         }
 
-        public List<MediaDirectory> ChildDirectory { get; set; }
+        private List<MediaDirectory> childDirectory;
+        public List<MediaDirectory> ChildDirectory {
+            get {
+                return childDirectory;
+            }
+            set {
+                SetProperty(ref childDirectory, value);
+                    childDirectory = value; 
+            }
+        }
         public FileInfo FileInfo { get; set; }
 
         public MediaDirectory() {

--- a/MusicPlayer/packages.config
+++ b/MusicPlayer/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Prism.Core" version="7.2.0.1422" targetFramework="net461" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" />
+</packages>

--- a/MusicPlayer/packages.config
+++ b/MusicPlayer/packages.config
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Expression.Blend.Sdk" version="1.0.2" targetFramework="net461" />
   <package id="Prism.Core" version="7.2.0.1422" targetFramework="net461" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" />
+  <package id="System.Windows.Interactivity.WPF" version="2.0.20525" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
- 機能追加 / ListViewItemのクリックイベントに、コマンドをバインド
- 仕様変更 / ディレクトリツリーにデフォルトのディレクトリを設定
- 機能追加 / MainWindow.Directoryが変更通知を出すよう修正
- 機能追加 / MediaDirectory.ChildDirectory が変更通知を出すよう修正
- 機能追加 / MediaDirectory に子ディレクトリを取得するメソッド、コマンドを追加
- xamlの機能拡張のため、 System.Windows.Interactivity  への参照を追加
- 仕様変更 / MediaDirectoryのNameの取得元を内部のFileInfoから取得に変更
- MVVM構築補助のためのライブラリ Prism を追加
- 機能追加 / ディレクトリツリーのソースとビューモデルのプロパティをバインド #14
- MainWindow に MainWindowViewModel を データコンテキストとして設定
- クラス追加 / MainWindowのViewModelを追加 #14

close #14
