### PR TITLE
バグ修正 / ディレクトリツリー上のディレクトリを再展開できない

### DIFF
--- a/MusicPlayer/model/MediaDirectory.cs
+++ b/MusicPlayer/model/MediaDirectory.cs
@@ -38,13 +38,15 @@ namespace MusicPlayer.model {
         }
 
         private void getChild() {
-            ChildDirectory = new List<MediaDirectory>();
+            var mediaDirectories = new List<MediaDirectory>();
             string[] childFileNames = System.IO.Directory.GetDirectories(FileInfo.FullName);
             foreach (string n in childFileNames) {
                 var md = new MediaDirectory();
                 md.FileInfo = new FileInfo(n);
-                ChildDirectory.Add(md);
+                mediaDirectories.Add(md);
             }
+
+            ChildDirectory = mediaDirectories;
         }
 
         public DelegateCommand GetChildsCommand { get; private set; }


### PR DESCRIPTION
従来は、最初に空のリストをChildDirectoryに代入後、そのリストにmediaDirectoryをaddしていたが、
この方法の場合、通常のListでは内部の要素の変更はビューに通知されず、空状態のまま変化しない。
なので、作ったListにMediaDirectoryを全て挿入したあとにListをChildDirectoryに代入するよう変更

close #19
