### PR TITLE
いくつかの情報を表示パーツをビューに追加

### DIFF
--- a/MusicPlayer/MainWindow.xaml
+++ b/MusicPlayer/MainWindow.xaml
@@ -75,6 +75,9 @@
                     <i:InvokeCommandAction Command="{Binding MediaFilesSettingCommand}"
                                            CommandParameter="{Binding ElementName=directoryTree, Path=SelectedItem}"
                                            />
+                    <i:InvokeCommandAction Command="{Binding SelectedDirectorySettingCommand}"
+                                           CommandParameter="{Binding ElementName=directoryTree, Path=SelectedItem}"
+                                           />
                 </i:EventTrigger>
             </i:Interaction.Triggers>
 
@@ -110,7 +113,7 @@
                    Grid.Row="1"
                    Grid.ColumnSpan="2" >
 
-            <Label Content="info"/>
+            <Label Content="{Binding SelectedDirectoryName, UpdateSourceTrigger=PropertyChanged}"/>
         </StatusBar>
     </Grid>
 

--- a/MusicPlayer/MainWindow.xaml
+++ b/MusicPlayer/MainWindow.xaml
@@ -31,38 +31,42 @@
             <ColumnDefinition/>
         </Grid.ColumnDefinitions>
 
-        <StackPanel Orientation="Horizontal"
-                    Grid.Row="0"
-                    >
-            <Button Content="play"
-                    Command="{Binding PlayCommand}"
-                    Padding="3"
-                    Margin="2"
-                    />
-            <Button Content="stop"
-                    Command="{Binding StopCommand}"
-                    Padding="3"
-                    Margin="2"
-                    />
+        <StackPanel>
+            <TextBlock Text="{Binding DoubleSoundPlayer.PlayingFileName, UpdateSourceTrigger=PropertyChanged}"/>
 
-            <TextBlock Text="mute"
-                       Margin="3"
-                       />
+            <StackPanel Orientation="Horizontal"
+                        Grid.Row="0"
+                        >
+                <Button Content="play"
+                        Command="{Binding PlayCommand}"
+                        Padding="3"
+                        Margin="2"
+                        />
+                <Button Content="stop"
+                        Command="{Binding StopCommand}"
+                        Padding="3"
+                        Margin="2"
+                        />
 
-            <Slider Name="VolumeControlSlider"
-                    Value="{Binding Volume}"
-                    AutoToolTipPlacement="TopLeft"
-                    SmallChange="2"
-                    Width="250"
-                    Maximum="100"
-                    Minimum="0"
-                    Margin="3"
-                    />
+                <TextBlock Text="mute"
+                           Margin="3"
+                           />
 
-            <TextBlock Text="max"
-                       Margin="3"
-                       />
+                <Slider Name="VolumeControlSlider"
+                        Value="{Binding Volume}"
+                        AutoToolTipPlacement="TopLeft"
+                        SmallChange="2"
+                        Width="250"
+                        Maximum="100"
+                        Minimum="0"
+                        Margin="3"
+                        />
 
+                <TextBlock Text="max"
+                           Margin="3"
+                           />
+
+            </StackPanel>
         </StackPanel>
 
         <TreeView Name="directoryTree"

--- a/MusicPlayer/MainWindow.xaml
+++ b/MusicPlayer/MainWindow.xaml
@@ -32,7 +32,9 @@
         </Grid.ColumnDefinitions>
 
         <StackPanel>
-            <TextBlock Text="{Binding DoubleSoundPlayer.PlayingFileName, UpdateSourceTrigger=PropertyChanged}"/>
+            <TextBlock Text="{Binding DoubleSoundPlayer.PlayingFileName, UpdateSourceTrigger=PropertyChanged}"
+                       Margin="2"
+                       />
 
             <StackPanel Orientation="Horizontal"
                         Grid.Row="0"

--- a/MusicPlayer/MainWindowViewModel.cs
+++ b/MusicPlayer/MainWindowViewModel.cs
@@ -61,6 +61,9 @@ namespace MusicPlayer {
             private set { mediaFilesSettingCommand = value; }
         }
 
+        public DelegateCommand<Object> SelectedDirectorySettingCommand { get; private set; }
+        public String SelectedDirectoryName { get; private set; }
+
         public DelegateCommand PlayCommand { get; private set; }
         public DelegateCommand StopCommand { get; private set; }
 
@@ -86,6 +89,14 @@ namespace MusicPlayer {
                     foreach(string n in selectedList) {
                         MediaFiles.Add(new FileInfo(n));
                     }
+                },
+                (Object param) => { return true; }
+            );
+
+            SelectedDirectorySettingCommand = new DelegateCommand<object>(
+                (Object param) => {
+                    SelectedDirectoryName = ((MediaDirectory)param).FileInfo.FullName;
+                    RaisePropertyChanged(nameof(SelectedDirectoryName));
                 },
                 (Object param) => { return true; }
             );

--- a/MusicPlayer/MainWindowViewModel.cs
+++ b/MusicPlayer/MainWindowViewModel.cs
@@ -15,6 +15,10 @@ namespace MusicPlayer {
         private List<MediaDirectory> directory = new List<MediaDirectory>();
         private DoubleSoundPlayer doubleSoundPlayer = new DoubleSoundPlayer();
 
+        public DoubleSoundPlayer DoubleSoundPlayer {
+            get { return doubleSoundPlayer; }
+        }
+
         public List<MediaDirectory> Directory {
             get {
                 return directory;

--- a/MusicPlayer/model/DoubleSoundPlayer.cs
+++ b/MusicPlayer/model/DoubleSoundPlayer.cs
@@ -59,9 +59,9 @@ namespace MusicPlayer.model {
             ((SoundPlayer)sender).stop();
             getOtherPlayer((SoundPlayer)sender).Volume = this.Volume;
             PlayingIndex += 1;
-            RaisePropertyChanged(nameof(PlayingFileName));
             SwitchPlayer();
             mediaSwitching = false;
+            RaisePropertyChanged(nameof(PlayingFileName));
         }
 
         private void DoubleSoundPlayer_mediaBeforeEndEvent(object sender) {
@@ -76,6 +76,7 @@ namespace MusicPlayer.model {
             }
 
             mediaSwitching = true;
+            RaisePropertyChanged(nameof(PlayingFileName));
         }
 
         public void play() {
@@ -107,6 +108,9 @@ namespace MusicPlayer.model {
         public String PlayingFileName {
             get {
                 if (Files == null || Files.Count <= PlayingIndex) return "";
+                else if (mediaSwitching && Files.Count > PlayingIndex + 1) {
+                    return Files[PlayingIndex].Name + " > " + Files[PlayingIndex + 1].Name;
+                }
                 return Files[PlayingIndex].Name;
             }
         }

--- a/MusicPlayer/model/DoubleSoundPlayer.cs
+++ b/MusicPlayer/model/DoubleSoundPlayer.cs
@@ -59,6 +59,7 @@ namespace MusicPlayer.model {
             ((SoundPlayer)sender).stop();
             getOtherPlayer((SoundPlayer)sender).Volume = this.Volume;
             PlayingIndex += 1;
+            RaisePropertyChanged(nameof(PlayingFileName));
             SwitchPlayer();
             mediaSwitching = false;
         }
@@ -78,6 +79,7 @@ namespace MusicPlayer.model {
         }
 
         public void play() {
+            RaisePropertyChanged(nameof(PlayingFileName));
             CurrentPlayer.SoundFileInfo = Files[PlayingIndex];
             CurrentPlayer.play();
         }
@@ -101,6 +103,13 @@ namespace MusicPlayer.model {
         public int PlayingIndex {
             get; set;
         } = 0;
+
+        public String PlayingFileName {
+            get {
+                if (Files == null || Files.Count <= PlayingIndex) return "";
+                return Files[PlayingIndex].Name;
+            }
+        }
 
         private void SwitchPlayer() {
             players.Reverse();

--- a/MusicPlayer/model/DoubleSoundPlayer.cs
+++ b/MusicPlayer/model/DoubleSoundPlayer.cs
@@ -1,14 +1,16 @@
-﻿using System;
+﻿using Prism.Mvvm;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
 using System.Timers;
 using System.Windows.Controls;
 
 namespace MusicPlayer.model {
-    class DoubleSoundPlayer {
+    class DoubleSoundPlayer : BindableBase{
         private List<SoundPlayer> players;
         private PlayerIndex currentPlayerIndex = PlayerIndex.First;
         private Timer timer = new Timer(450);


### PR DESCRIPTION
- 機能追加 / 曲の切り替わり中は、現在の曲と次の曲の両方のタイトルを表示
- 機能追加 / ウィンドウ上部に再生中のファイル名を表示する機能を追加
- DoubeSoundPlayer を BindableBaseから継承
- ビューモデルの doubleSoundPlayer を取得できるプロパティを公開
- 機能追加 / ウィンドウ下部のステータスバーに、選択中のディレクトリを表示

close #31
