### PR TITLE
不定期に出るアクセス時のエラーの頻度を減らす

### DIFF
--- a/MusicPlayer/model/SoundPlayer.cs
+++ b/MusicPlayer/model/SoundPlayer.cs
@@ -32,8 +32,8 @@ namespace MusicPlayer.model {
             };
 
             timer.Elapsed += (sender, e) => {
-                if(Duration > 0 && Position >= Duration - SecondsOfBeforeEndNotice) {
-                    if (!hasNotifiedBeforeEnd) {
+                if (!hasNotifiedBeforeEnd) {
+                    if(Duration > 0 && Position >= Duration - SecondsOfBeforeEndNotice) {
                         mediaBeforeEndEvent(this);
                         hasNotifiedBeforeEnd = true;
                     }

--- a/MusicPlayer/model/SoundPlayer.cs
+++ b/MusicPlayer/model/SoundPlayer.cs
@@ -94,6 +94,9 @@ namespace MusicPlayer.model {
                 return wmp.controls.currentPosition;
             }
             set {
+                if(value >= Duration - SecondsOfBeforeEndNotice) {
+                    hasNotifiedBeforeEnd = false;
+                }
                 wmp.controls.currentPosition = value;
             }
         }

--- a/MusicPlayer/model/SoundPlayer.cs
+++ b/MusicPlayer/model/SoundPlayer.cs
@@ -25,9 +25,12 @@ namespace MusicPlayer.model {
             wmp.settings.volume = 100;
 
             wmp.PlayStateChange += (int NewState) => {
+                    Duration = wmp.currentMedia.duration;
                 if (Duration < SecondsOfBeforeEndNotice * 2) hasNotifiedBeforeEnd = true;
                 else hasNotifiedBeforeEnd = false;
-                if (NewState == (int)WMPPlayState.wmppsPlaying) playStartedEvent?.Invoke(this);
+                if (NewState == (int)WMPPlayState.wmppsPlaying) {
+                    playStartedEvent?.Invoke(this);
+                }
             };
 
             wmp.PlayStateChange += (int NewState) => {
@@ -109,12 +112,7 @@ namespace MusicPlayer.model {
             }
         }
 
-        public double Duration {
-            get {
-                if (wmp.currentMedia != null) return wmp.currentMedia.duration;
-                else return 0;
-            }
-        }
+        public double Duration { get; private set; } = 0;
 
         public Boolean Playing {
             get;

--- a/MusicPlayer/model/SoundPlayer.cs
+++ b/MusicPlayer/model/SoundPlayer.cs
@@ -30,10 +30,8 @@ namespace MusicPlayer.model {
                     playTimeCounter.Start();
 
                     Duration = wmp.currentMedia.duration;
-                    Debug.WriteLine(GetHashCode() + " " + Duration);
                     if (Duration < SecondsOfBeforeEndNotice * 2) hasNotifiedBeforeEnd = true;
                     else hasNotifiedBeforeEnd = false;
-                    Debug.WriteLine(GetHashCode() + " " + hasNotifiedBeforeEnd);
                     playStartedEvent?.Invoke(this);
                 }
             };
@@ -50,7 +48,6 @@ namespace MusicPlayer.model {
 
             timer.Elapsed += (sender, e) => {
                 if (!hasNotifiedBeforeEnd) {
-                    System.Diagnostics.Debug.WriteLine(Duration + " " + Position);
                     if(Duration > 0 && Position >= Duration - SecondsOfBeforeEndNotice) {
                         mediaBeforeEndEvent(this);
                         hasNotifiedBeforeEnd = true;

--- a/MusicPlayer/model/SoundPlayer.cs
+++ b/MusicPlayer/model/SoundPlayer.cs
@@ -28,6 +28,7 @@ namespace MusicPlayer.model {
                 if (NewState == (int)WMPPlayState.wmppsPlaying) {
                     playTimeCounter.Reset();
                     playTimeCounter.Start();
+                    additionTimeCount = 0;
 
                     Duration = wmp.currentMedia.duration;
                     if (Duration < SecondsOfBeforeEndNotice * 2) hasNotifiedBeforeEnd = true;
@@ -74,6 +75,7 @@ namespace MusicPlayer.model {
         private Timer timer = new Timer(1000);
         private Boolean hasNotifiedBeforeEnd = false;
         private Stopwatch playTimeCounter = new Stopwatch();
+        private double additionTimeCount = 0;
 
         public void play() {
             wmp.URL = soundFileInfo.FullName;
@@ -93,6 +95,7 @@ namespace MusicPlayer.model {
         public void stop() {
             playTimeCounter.Stop();
             playTimeCounter.Reset();
+            additionTimeCount = 0;
             wmp.controls.stop();
             Playing = false;
         }
@@ -109,12 +112,17 @@ namespace MusicPlayer.model {
 
         public double Position {
             get {
-                return (playTimeCounter.Elapsed.Minutes * 60) + playTimeCounter.Elapsed.Seconds;
+                return additionTimeCount + (playTimeCounter.Elapsed.Minutes * 60) + playTimeCounter.Elapsed.Seconds;
             }
             set {
                 if(value >= Duration - SecondsOfBeforeEndNotice) {
                     hasNotifiedBeforeEnd = false;
                 }
+
+                if (playTimeCounter.IsRunning) playTimeCounter.Restart();
+                else playTimeCounter.Reset();
+                additionTimeCount = value;
+
                 wmp.controls.currentPosition = value;
             }
         }

--- a/MusicPlayer/model/SoundPlayer.cs
+++ b/MusicPlayer/model/SoundPlayer.cs
@@ -25,7 +25,9 @@ namespace MusicPlayer.model {
             wmp.settings.volume = 100;
 
             wmp.PlayStateChange += (int NewState) => {
-                if (NewState == (int)WMPPlayState.wmppsPlaying) playStartedEvent(this);
+                if (Duration < SecondsOfBeforeEndNotice * 2) hasNotifiedBeforeEnd = true;
+                else hasNotifiedBeforeEnd = false;
+                if (NewState == (int)WMPPlayState.wmppsPlaying) playStartedEvent?.Invoke(this);
             };
 
             wmp.PlayStateChange += (int NewState) => {
@@ -68,7 +70,6 @@ namespace MusicPlayer.model {
         public void play() {
             wmp.URL = soundFileInfo.FullName;
             Playing = true;
-            hasNotifiedBeforeEnd = false;
         }
 
         public void pause() {

--- a/MusicPlayer/model/SoundPlayer.cs
+++ b/MusicPlayer/model/SoundPlayer.cs
@@ -17,11 +17,17 @@ namespace MusicPlayer.model {
 
     delegate void MediaEndedEventHandler(object sender);
     delegate void MediaBeforeEndEventHandler(object sender);
+    delegate void PlayStartedEventHandler(object sender);
 
     class SoundPlayer {
 
         public SoundPlayer() {
             wmp.settings.volume = 100;
+
+            wmp.PlayStateChange += (int NewState) => {
+                if (NewState == (int)WMPPlayState.wmppsPlaying) playStartedEvent(this);
+            };
+
             wmp.PlayStateChange += (int NewState) => {
 
                 //  statusの番号については、MSのドキュメント "PlayStateChange Event of the AxWindowsMediaPlayer Object" を参照
@@ -55,6 +61,7 @@ namespace MusicPlayer.model {
         private WindowsMediaPlayer wmp = new WindowsMediaPlayer();
         public event MediaEndedEventHandler mediaEndedEvent;
         public event MediaBeforeEndEventHandler mediaBeforeEndEvent;
+        public event PlayStartedEventHandler playStartedEvent;
         private Timer timer = new Timer(1000);
         private Boolean hasNotifiedBeforeEnd = false;
 


### PR DESCRIPTION
SoundPlayer内部では極力wmpインスタンスへアクセスしないことにより頻度を減らした。
エラーの頻度は減らせたように思うが、まだエラーが出る余地は残っているように思うので、別のブランチで対応する。

- バグ修正試行 / wmpへのアクセス頻度を減らすため、条件分岐の順番を入れ替え
- 仕様変更 / Position プロパティ内に終了前通知を出したかどうかのフラグをリセットするコードを追加
- 機能追加 / SoundPlayer にメディア再生開始を通知するイベントを追加
- バグ修正 / 短い曲を再生する際、wmpに連続アクセスするケースが発生していたのを修正
- 仕様変更 / Duration の取得ソースをSoundPlayerのプロパティに変更
- 機能追加 / Positionの取得元をStopWatchに変更
- デバッグ用のコードが残ってしまっていたので削除
- 機能追加 / Positionをsetterから変更した際、変更した値を保持する処理を追加
