### PR TITLE
バグ修正 / null状態のフィールドにアクセスする場合があったのを修正

### DIFF
--- a/MusicPlayer/MainWindowViewModel.cs
+++ b/MusicPlayer/MainWindowViewModel.cs
@@ -30,7 +30,7 @@ namespace MusicPlayer {
             }
         }
 
-        private List<FileInfo> mediaFiles;
+        private List<FileInfo> mediaFiles = new List<FileInfo>();
         public List<FileInfo> MediaFiles {
             get {
                 return mediaFiles;
@@ -191,23 +191,24 @@ namespace MusicPlayer {
         public DelegateCommand RandomSortCommand {
             get => randomSortCommand ?? (randomSortCommand = new DelegateCommand(
                 () => {
-                    if(MediaFiles.Count == 0) {
-                        return;
-                    }
-
                     Random r = new Random();
                     MediaFiles = MediaFiles.OrderBy(m => r.Next(MediaFiles.Count)).ToList();
-                }
-            ));
+                },
+                () => MediaFiles.Count > 0
+            )).ObservesProperty(() => MediaFiles);
         }
 
         private DelegateCommand nameOrderSortCommand;
         public DelegateCommand NameOrderSortCommand {
             get => nameOrderSortCommand ?? (nameOrderSortCommand = new DelegateCommand(
                 () => {
-                    MediaFiles = MediaFiles.OrderBy(m => m.Name).ToList();
-                }
-            ));
+                    if (MediaFiles != null && MediaFiles.Count > 0) {
+                        MediaFiles = MediaFiles.OrderBy(m => m.Name).ToList();
+                    }
+
+                },
+                () => MediaFiles.Count > 0
+            )).ObservesProperty(() => MediaFiles);
         }
     }
 }


### PR DESCRIPTION
起動直後はMediaFilesの中身がnullであり、初期化時にインスタンスを入れていなかったため、このリストを使用するとエラーになっていた。
初期化時に値を入力するようにし、またソートボタンはカウントが０より大きくなければそもそも押せないように変更して修正

close #48
