### PR TITLE
バグ修正 / m3u ファイルに空白行が含まれていた場合にアプリが落ちる不具合を修正

### DIFF
--- a/MusicPlayer/model/MediaDirectory.cs
+++ b/MusicPlayer/model/MediaDirectory.cs
@@ -79,7 +79,12 @@ namespace MusicPlayer.model {
             var fileList = new List<FileInfo>();
             string[] fileNames = File.ReadAllLines(FileInfo.FullName);
             foreach(var n in fileNames) {
-                fileList.Add(new FileInfo(n));
+                if(n.Trim().Length > 0) {
+                    FileInfo f = new FileInfo(n);
+                    if (f.Exists) {
+                        fileList.Add(new FileInfo(n));
+                    }
+                }
             }
 
             return fileList;


### PR DESCRIPTION
m3u ファイルを行ごとに分割して得られた文字列をチェックするようコードを修正。

close #49
