### PR TITLE
バグ修正 / 曲をダブルクリックで再生した際、曲名が更新されない件を修正

### DIFF
--- a/MusicPlayer/model/DoubleSoundPlayer.cs
+++ b/MusicPlayer/model/DoubleSoundPlayer.cs
@@ -119,6 +119,7 @@ namespace MusicPlayer.model {
                     CurrentPlayer.SoundFileInfo = f;
                     PlayingIndex = Files.IndexOf(f);
                     CurrentPlayer.play();
+                    RaisePropertyChanged(nameof(PlayingFileName));
                 }
             ));
         }


### PR DESCRIPTION
close #59
