### PR TITLE
SoundPlayerクラスから Timew を使用した処理を削除する

### DIFF
--- a/MusicPlayer/model/DoubleSoundPlayer.cs
+++ b/MusicPlayer/model/DoubleSoundPlayer.cs
@@ -65,51 +65,6 @@ namespace MusicPlayer.model {
             }
         }
 
-        private void DoubleSoundPlayer_mediaEndedEvent(object sender) {
-            ((SoundPlayer)sender).Volume = 0;
-            ((SoundPlayer)sender).stop();
-            PlayingIndex += 1;
-            SoundPlayer otherPlayer = getOtherPlayer((SoundPlayer)sender);
-
-            getOtherPlayer((SoundPlayer)sender).Volume = this.Volume;
-            if (!otherPlayer.Playing && Files.Count > PlayingIndex) {
-                otherPlayer.SoundFileInfo = Files[PlayingIndex];
-                otherPlayer.play();
-            }
-
-            SwitchPlayer();
-            mediaSwitching = false;
-            RaisePropertyChanged(nameof(PlayingFileName));
-            SelectedItem = Files[PlayingIndex];
-        }
-
-        private void DoubleSoundPlayer_mediaBeforeEndEvent(object sender) {
-            // イベントを送出したプレイヤーでない方のプレイヤーに対して操作を行う
-            // なので、センダーではない方のプレイヤーを代入する
-            SoundPlayer player = getOtherPlayer((SoundPlayer)sender);
-
-            if(Files.Count > PlayingIndex + 1) {
-                player.playStartedEvent += Player_playStartedEvent;
-                player.SoundFileInfo = Files[PlayingIndex + 1];
-                player.play();
-                player.Volume = 0;
-            }
-
-            mediaSwitching = true;
-            RaisePropertyChanged(nameof(PlayingFileName));
-
-        }
-
-        private void Player_playStartedEvent(object sender) {
-            SoundPlayer player = (SoundPlayer)sender;
-            if(player.Duration <= SwitchingDuration * 2) {
-                mediaSwitching = false;
-                player.stop();
-            }
-
-            player.playStartedEvent -= Player_playStartedEvent;
-        }
-
         public void play() {
             SelectedItem = Files[PlayingIndex];
             RaisePropertyChanged(nameof(PlayingFileName));
@@ -178,10 +133,6 @@ namespace MusicPlayer.model {
                 }
                 return Files[PlayingIndex].Name;
             }
-        }
-
-        private void SwitchPlayer() {
-            players.Reverse();
         }
 
         /// <summary>

--- a/MusicPlayer/model/DoubleSoundPlayer.cs
+++ b/MusicPlayer/model/DoubleSoundPlayer.cs
@@ -37,12 +37,27 @@ namespace MusicPlayer.model {
                 RaisePropertyChanged(nameof(PlayTime));
                 SoundPlayer player = eitherBeforePlayEnd;
                 if(player != null) {
+
+                    // ボリュームの操作等の曲の切り替え中の動作をここに記述する
                     SoundPlayer otherPlayer = getOtherPlayer(player);
+
+                    int volumeUpAmount = (SwitchingDuration != 0) ? Volume / SwitchingDuration : 0;
+                    int volumeDownAmount = (SwitchingDuration != 0) ? Volume / SwitchingDuration : 0;
+
+                    if(otherPlayer.Volume + volumeUpAmount < Volume) {
+                        otherPlayer.Volume += volumeUpAmount;
+                    }
+                    else {
+                        otherPlayer.Volume = Volume;
+                    }
+
+                    player.Volume -= Volume / switchingDuration / 2;
 
                     if (!otherPlayer.Playing) {
                         PlayingIndex++;
                         otherPlayer.SoundFileInfo = Files[PlayingIndex];
                         otherPlayer.play();
+                        otherPlayer.Volume = 0;
                     }
 
                 }

--- a/MusicPlayer/model/DoubleSoundPlayer.cs
+++ b/MusicPlayer/model/DoubleSoundPlayer.cs
@@ -33,29 +33,36 @@ namespace MusicPlayer.model {
             players.Add(soundPlayerA);
             players.Add(soundPlayerB);
 
-            soundPlayerA.mediaBeforeEndEvent += DoubleSoundPlayer_mediaBeforeEndEvent;
-            soundPlayerB.mediaBeforeEndEvent += DoubleSoundPlayer_mediaBeforeEndEvent;
-
-            soundPlayerA.mediaEndedEvent += DoubleSoundPlayer_mediaEndedEvent;
-            soundPlayerB.mediaEndedEvent += DoubleSoundPlayer_mediaEndedEvent;
-
-
             timer.Elapsed += (source, e) => {
                 RaisePropertyChanged(nameof(PlayTime));
+                SoundPlayer player = eitherBeforePlayEnd;
+                if(player != null) {
+                    SoundPlayer otherPlayer = getOtherPlayer(player);
 
-                if (mediaSwitching) {
-                    int volumeUp = Convert.ToInt32(Math.Ceiling((double)this.Volume / (switchingDuration)));
-                    int volumeDown = Convert.ToInt32(Math.Ceiling((double)this.Volume / (switchingDuration) / 2));
-                    if (players[(int)PlayerIndex.First].Volume - volumeDown >= 0) {
-                        players[(int)PlayerIndex.First].Volume -= volumeDown;
+                    if (!otherPlayer.Playing) {
+                        PlayingIndex++;
+                        otherPlayer.SoundFileInfo = Files[PlayingIndex];
+                        otherPlayer.play();
                     }
-                    if (players[(int)PlayerIndex.Second].Volume + volumeUp <= Volume) {
-                        players[(int)PlayerIndex.Second].Volume += volumeUp;
-                    }
+
                 }
             };
 
             timer.Start();
+        }
+
+        /// <summary>
+        /// ２つのプレイヤーのうち、どちらか片方だけが終了直前のとき、そのプレイヤーを返します。
+        /// 両方のプレイヤーが終了直前、または終了直前ではない場合、null を返します。
+        /// </summary>
+        private SoundPlayer eitherBeforePlayEnd {
+            get {
+                if(players[0].PassedBeforeEndPoint == players[1].PassedBeforeEndPoint){
+                    return null;
+                }
+
+                return players[0].PassedBeforeEndPoint ? players[0] : players[1];
+            }
         }
 
         private void DoubleSoundPlayer_mediaEndedEvent(object sender) {

--- a/MusicPlayer/model/SoundPlayer.cs
+++ b/MusicPlayer/model/SoundPlayer.cs
@@ -53,7 +53,6 @@ namespace MusicPlayer.model {
 
         private WindowsMediaPlayer wmp = new WindowsMediaPlayer();
         public event MediaEndedEventHandler mediaEndedEvent;
-        public event MediaBeforeEndEventHandler mediaBeforeEndEvent;
         public event PlayStartedEventHandler playStartedEvent;
         private Boolean hasNotifiedBeforeEnd = false;
 

--- a/MusicPlayer/model/SoundPlayer.cs
+++ b/MusicPlayer/model/SoundPlayer.cs
@@ -59,6 +59,7 @@ namespace MusicPlayer.model {
 
         public void play() {
             wmp.URL = soundFileInfo.FullName;
+            wmp.controls.currentPosition = FrontCut;
             Playing = true;
         }
 
@@ -119,7 +120,29 @@ namespace MusicPlayer.model {
         /// 終了直前のポイントとは、"Duration - SecondsOfBeforeEndNotice" の値が示す時点です。
         /// </summary>
         public bool PassedBeforeEndPoint {
-            get => (Position >= Duration - SecondsOfBeforeEndNotice);
+            get => (Position >= Duration - SecondsOfBeforeEndNotice - BackCut);
+        }
+
+        /// <summary>
+        /// このメディアの実際の Duration から BackCut を引いた時点を通過したかどうかを取得します。
+        /// このプロパティが true を返す場合、実質的にメディアの再生が終了していることを意味します。
+        /// </summary>
+        public bool PssedBackCutPoint {
+            get => (Position >= Duration - BackCut);
+        }
+
+        /// <summary>
+        /// 曲の先頭部分を指定秒数カットします。
+        /// </summary>
+        public int FrontCut {
+            get; set;
+        }
+
+        /// <summary>
+        /// 曲の終端部分を指定秒数カットします。
+        /// </summary>
+        public int BackCut {
+            get; set;
         }
     }
 }

--- a/MusicPlayer/model/SoundPlayer.cs
+++ b/MusicPlayer/model/SoundPlayer.cs
@@ -37,7 +37,7 @@ namespace MusicPlayer.model {
                 //  statusの番号については、MSのドキュメント "PlayStateChange Event of the AxWindowsMediaPlayer Object" を参照
                 //  ここで使用する８番は再生終了時のステータスとなっている。
                 if (NewState == 8) {
-                    mediaEndedEvent(this);
+                    mediaEndedEvent?.Invoke(this);
                 }
             };
         }
@@ -108,11 +108,18 @@ namespace MusicPlayer.model {
         } = false;
 
         /// <summary>
-        /// SoundPlayerオブジェクトは現在流れている曲の終了N秒前になるとイベントを送出する。
-        /// このとき、上記の N の値はこのプロパティにセットした値となる。
+        /// PassedBeforeEndPoint 実行時、メディアが終了直前と判定されるポイントを指定します。
         /// </summary>
         public int SecondsOfBeforeEndNotice {
             get; set;
+        }
+
+        /// <summary>
+        /// このメディアが終了直前のポイントを通り過ぎたかどうかを取得します。
+        /// 終了直前のポイントとは、"Duration - SecondsOfBeforeEndNotice" の値が示す時点です。
+        /// </summary>
+        public bool PassedBeforeEndPoint {
+            get => (Position >= Duration - SecondsOfBeforeEndNotice);
         }
     }
 }

--- a/MusicPlayer/model/SoundPlayer.cs
+++ b/MusicPlayer/model/SoundPlayer.cs
@@ -120,7 +120,12 @@ namespace MusicPlayer.model {
         /// 終了直前のポイントとは、"Duration - SecondsOfBeforeEndNotice" の値が示す時点です。
         /// </summary>
         public bool PassedBeforeEndPoint {
-            get => (Position >= Duration - SecondsOfBeforeEndNotice - BackCut);
+            get {
+                if (Duration == 0) {
+                    return false;
+                }
+                return (Position >= Duration - SecondsOfBeforeEndNotice - BackCut);
+            }
         }
 
         /// <summary>

--- a/MusicPlayer/model/SoundPlayer.cs
+++ b/MusicPlayer/model/SoundPlayer.cs
@@ -8,7 +8,6 @@ using System.Runtime.InteropServices.WindowsRuntime;
 using System.Runtime.Remoting.Channels;
 using System.Text;
 using System.Threading.Tasks;
-using System.Timers;
 using System.Windows.Media;
 using System.Windows.Navigation;
 using WMPLib;
@@ -46,17 +45,6 @@ namespace MusicPlayer.model {
                     mediaEndedEvent(this);
                 }
             };
-
-            timer.Elapsed += (sender, e) => {
-                if (!hasNotifiedBeforeEnd) {
-                    if(Duration > 0 && Position >= Duration - SecondsOfBeforeEndNotice) {
-                        mediaBeforeEndEvent(this);
-                        hasNotifiedBeforeEnd = true;
-                    }
-                }
-            };
-
-            timer.Start();
         }
 
         private FileInfo soundFileInfo;
@@ -72,7 +60,6 @@ namespace MusicPlayer.model {
         public event MediaEndedEventHandler mediaEndedEvent;
         public event MediaBeforeEndEventHandler mediaBeforeEndEvent;
         public event PlayStartedEventHandler playStartedEvent;
-        private Timer timer = new Timer(1000);
         private Boolean hasNotifiedBeforeEnd = false;
         private Stopwatch playTimeCounter = new Stopwatch();
         private double additionTimeCount = 0;

--- a/MusicPlayer/model/SoundPlayer.cs
+++ b/MusicPlayer/model/SoundPlayer.cs
@@ -60,22 +60,18 @@ namespace MusicPlayer.model {
         public void play() {
             wmp.URL = soundFileInfo.FullName;
             wmp.controls.currentPosition = FrontCut;
-            Playing = true;
         }
 
         public void pause() {
             wmp.controls.pause();
-            Playing = false;
         }
 
         public void resume() {
             wmp.controls.play();
-            Playing = true;
         }
 
         public void stop() {
             wmp.controls.stop();
-            Playing = false;
         }
 
         public int Volume {
@@ -104,9 +100,10 @@ namespace MusicPlayer.model {
         public double Duration { get; private set; } = 0;
 
         public Boolean Playing {
-            get;
-            private set;
-        } = false;
+            get => (wmp.playState == WMPPlayState.wmppsPlaying);
+            private set{
+            }
+        }
 
         /// <summary>
         /// PassedBeforeEndPoint 実行時、メディアが終了直前と判定されるポイントを指定します。

--- a/MusicPlayer/model/SoundPlayer.cs
+++ b/MusicPlayer/model/SoundPlayer.cs
@@ -78,8 +78,15 @@ namespace MusicPlayer.model {
                 return wmp.settings.volume;
             }
             set {
-                if (value > 100 || value < 0) throw new ArgumentException("ボリュームの値は 0 - 100 の値を入力してください");
-                wmp.settings.volume = value;
+                if(value > 100) {
+                    wmp.settings.volume = 100;
+                }
+                else if(value < 0) {
+                    wmp.settings.volume = 0;
+                }
+                else {
+                    wmp.settings.volume = value;
+                }
             }
         }
 

--- a/MusicPlayer/model/SoundPlayer.cs
+++ b/MusicPlayer/model/SoundPlayer.cs
@@ -25,10 +25,6 @@ namespace MusicPlayer.model {
 
             wmp.PlayStateChange += (int NewState) => {
                 if (NewState == (int)WMPPlayState.wmppsPlaying) {
-                    playTimeCounter.Reset();
-                    playTimeCounter.Start();
-                    additionTimeCount = 0;
-
                     Duration = wmp.currentMedia.duration;
                     if (Duration < SecondsOfBeforeEndNotice * 2) hasNotifiedBeforeEnd = true;
                     else hasNotifiedBeforeEnd = false;
@@ -41,7 +37,6 @@ namespace MusicPlayer.model {
                 //  statusの番号については、MSのドキュメント "PlayStateChange Event of the AxWindowsMediaPlayer Object" を参照
                 //  ここで使用する８番は再生終了時のステータスとなっている。
                 if (NewState == 8) {
-                    playTimeCounter.Stop();
                     mediaEndedEvent(this);
                 }
             };
@@ -61,8 +56,6 @@ namespace MusicPlayer.model {
         public event MediaBeforeEndEventHandler mediaBeforeEndEvent;
         public event PlayStartedEventHandler playStartedEvent;
         private Boolean hasNotifiedBeforeEnd = false;
-        private Stopwatch playTimeCounter = new Stopwatch();
-        private double additionTimeCount = 0;
 
         public void play() {
             wmp.URL = soundFileInfo.FullName;
@@ -80,9 +73,6 @@ namespace MusicPlayer.model {
         }
 
         public void stop() {
-            playTimeCounter.Stop();
-            playTimeCounter.Reset();
-            additionTimeCount = 0;
             wmp.controls.stop();
             Playing = false;
         }
@@ -99,16 +89,12 @@ namespace MusicPlayer.model {
 
         public double Position {
             get {
-                return additionTimeCount + (playTimeCounter.Elapsed.Minutes * 60) + playTimeCounter.Elapsed.Seconds;
+                return wmp.controls.currentPosition;
             }
             set {
                 if(value >= Duration - SecondsOfBeforeEndNotice) {
                     hasNotifiedBeforeEnd = false;
                 }
-
-                if (playTimeCounter.IsRunning) playTimeCounter.Restart();
-                else playTimeCounter.Reset();
-                additionTimeCount = value;
 
                 wmp.controls.currentPosition = value;
             }


### PR DESCRIPTION
- 機能削除 / SoundPlayer から Timer を削除
- 機能削除 / SoundPlayer から Stopwatch を削除
- 機能追加 / イベントを飛ばす代わりに、終了直前のポイントを過ぎたかを判定するメソッドを追加
- 機能追加 / 曲の始めと終わりを指定秒数カットする機能を追加
- 機能修正 / Duration == 0 なら常に終了直前扱いされていたのを修正
- 機能修正 / Playing のソースを wmp オブジェクトに変更
- 機能追加 / 単一の timer イベントハンドラで連続で曲を再生できるように実装
- 機能削除 / SoundPlayer, DoubleSoundPlayer から未使用になったメソッドを削除
- 機能修正 / Volume プロパティにセット時、不正な値が来ても例外を投げないよう修正
- 機能追加 / 曲の切替時に音量がクロスフェードするよう実装

close #63
