### PR TITLE
SoundPlayerのテストを作成する

### DIFF
--- a/MusicPlayer.sln
+++ b/MusicPlayer.sln
@@ -1,9 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28307.329
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30204.135
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MusicPlayer", "MusicPlayer\MusicPlayer.csproj", "{D9ECFC5B-B6F9-4F87-A81E-3AEFFE5FF3FD}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MusicPlayerTests3", "MusicPlayerTests3\MusicPlayerTests3.csproj", "{9280C61E-F581-4B6A-8EE4-D00F63D02F90}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,6 +17,10 @@ Global
 		{D9ECFC5B-B6F9-4F87-A81E-3AEFFE5FF3FD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D9ECFC5B-B6F9-4F87-A81E-3AEFFE5FF3FD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D9ECFC5B-B6F9-4F87-A81E-3AEFFE5FF3FD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9280C61E-F581-4B6A-8EE4-D00F63D02F90}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9280C61E-F581-4B6A-8EE4-D00F63D02F90}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9280C61E-F581-4B6A-8EE4-D00F63D02F90}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9280C61E-F581-4B6A-8EE4-D00F63D02F90}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/MusicPlayer/MainWindowViewModel.cs
+++ b/MusicPlayer/MainWindowViewModel.cs
@@ -14,7 +14,7 @@ namespace MusicPlayer {
     class MainWindowViewModel : BindableBase{
 
         private List<MediaDirectory> directory = new List<MediaDirectory>();
-        private DoubleSoundPlayer doubleSoundPlayer = new DoubleSoundPlayer();
+        private DoubleSoundPlayer doubleSoundPlayer;
 
         public DoubleSoundPlayer DoubleSoundPlayer {
             get { return doubleSoundPlayer; }
@@ -147,6 +147,11 @@ namespace MusicPlayer {
             var path = (new DirectoryInfo(Properties.Settings.Default.DefaultBaseDirectoryPath).Exists) ?
                 Properties.Settings.Default.DefaultBaseDirectoryPath : @"C:\";
             BaseDirectoryPath = path;
+
+            doubleSoundPlayer = new DoubleSoundPlayer(
+                new SoundPlayer(new WMPWrapper()),
+                new SoundPlayer(new WMPWrapper())
+            );
 
             playerSetting = new PlayerSetting();
             playerSetting.DefaultBaseDirectoryPath = path;

--- a/MusicPlayer/MusicPlayer.csproj
+++ b/MusicPlayer/MusicPlayer.csproj
@@ -89,7 +89,9 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </ApplicationDefinition>
+    <Compile Include="model\IPlayer.cs" />
     <Compile Include="model\PlayerSetting.cs" />
+    <Compile Include="model\WMPWrapper.cs" />
     <Compile Include="SettingWindow.xaml.cs">
       <DependentUpon>SettingWindow.xaml</DependentUpon>
     </Compile>

--- a/MusicPlayer/model/DoubleSoundPlayer.cs
+++ b/MusicPlayer/model/DoubleSoundPlayer.cs
@@ -27,8 +27,8 @@ namespace MusicPlayer.model {
 
         public DoubleSoundPlayer() {
             players = new List<SoundPlayer>(2); // 今の所、要素数２より大きくする必要はない
-            SoundPlayer soundPlayerA = new SoundPlayer();
-            SoundPlayer soundPlayerB = new SoundPlayer();
+            SoundPlayer soundPlayerA = new SoundPlayer(new WMPWrapper());
+            SoundPlayer soundPlayerB = new SoundPlayer(new WMPWrapper());
 
             players.Add(soundPlayerA);
             players.Add(soundPlayerB);

--- a/MusicPlayer/model/DoubleSoundPlayer.cs
+++ b/MusicPlayer/model/DoubleSoundPlayer.cs
@@ -11,7 +11,7 @@ using System.Timers;
 using System.Windows.Controls;
 
 namespace MusicPlayer.model {
-    class DoubleSoundPlayer : BindableBase{
+    public class DoubleSoundPlayer : BindableBase{
         private List<SoundPlayer> players;
         private PlayerIndex currentPlayerIndex = PlayerIndex.First;
         private Timer timer = new Timer(450);

--- a/MusicPlayer/model/DoubleSoundPlayer.cs
+++ b/MusicPlayer/model/DoubleSoundPlayer.cs
@@ -30,6 +30,9 @@ namespace MusicPlayer.model {
             SoundPlayer soundPlayerA = playerA;
             SoundPlayer soundPlayerB = playerB;
 
+            soundPlayerA.mediaEndedEvent += nextPlay;
+            soundPlayerB.mediaEndedEvent += nextPlay;
+
             players.Add(soundPlayerA);
             players.Add(soundPlayerB);
 
@@ -78,6 +81,13 @@ namespace MusicPlayer.model {
 
                 return players[0].PassedBeforeEndPoint ? players[0] : players[1];
             }
+        }
+
+        private void nextPlay(object sender) {
+            PlayingIndex++;
+            SoundPlayer p = sender as SoundPlayer;
+            p.SoundFileInfo = Files[PlayingIndex];
+            p.play();
         }
 
         public void play() {

--- a/MusicPlayer/model/DoubleSoundPlayer.cs
+++ b/MusicPlayer/model/DoubleSoundPlayer.cs
@@ -25,10 +25,10 @@ namespace MusicPlayer.model {
 
         }
 
-        public DoubleSoundPlayer() {
+        public DoubleSoundPlayer(SoundPlayer playerA, SoundPlayer playerB) {
             players = new List<SoundPlayer>(2); // 今の所、要素数２より大きくする必要はない
-            SoundPlayer soundPlayerA = new SoundPlayer(new WMPWrapper());
-            SoundPlayer soundPlayerB = new SoundPlayer(new WMPWrapper());
+            SoundPlayer soundPlayerA = playerA;
+            SoundPlayer soundPlayerB = playerB;
 
             players.Add(soundPlayerA);
             players.Add(soundPlayerB);

--- a/MusicPlayer/model/DoubleSoundPlayer.cs
+++ b/MusicPlayer/model/DoubleSoundPlayer.cs
@@ -61,6 +61,9 @@ namespace MusicPlayer.model {
                 }
 
                 if (!otherPlayer.Playing) {
+                    if(Files.Count < PlayingIndex + 1) {
+                        return;
+                    }
 
                     PlayingIndex++;
                     otherPlayer.SoundFileInfo = Files[PlayingIndex];
@@ -123,9 +126,11 @@ namespace MusicPlayer.model {
 
             // 逆側のプレイヤーが再生している状態の場合は、このハンドラ内で play() を呼び出すことは無い
             if (!anotherPlayer.Playing) {
-                PlayingIndex++;
-                p.SoundFileInfo = Files[PlayingIndex];
-                p.play();
+                if(Files.Count > PlayingIndex + 1) {
+                    PlayingIndex++;
+                    p.SoundFileInfo = Files[PlayingIndex];
+                    p.play();
+                }
             }
         }
 

--- a/MusicPlayer/model/DoubleSoundPlayer.cs
+++ b/MusicPlayer/model/DoubleSoundPlayer.cs
@@ -37,36 +37,39 @@ namespace MusicPlayer.model {
             players.Add(soundPlayerB);
 
             timer.Elapsed += (source, e) => {
-                RaisePropertyChanged(nameof(PlayTime));
-                SoundPlayer player = eitherBeforePlayEnd;
-                if(player != null) {
-
-                    // ボリュームの操作等の曲の切り替え中の動作をここに記述する
-                    SoundPlayer otherPlayer = getOtherPlayer(player);
-
-                    int volumeUpAmount = (SwitchingDuration != 0) ? Volume / SwitchingDuration : 0;
-                    int volumeDownAmount = (SwitchingDuration != 0) ? Volume / SwitchingDuration : 0;
-
-                    if(otherPlayer.Volume + volumeUpAmount < Volume) {
-                        otherPlayer.Volume += volumeUpAmount;
-                    }
-                    else {
-                        otherPlayer.Volume = Volume;
-                    }
-
-                    player.Volume -= Volume / switchingDuration / 2;
-
-                    if (!otherPlayer.Playing) {
-                        PlayingIndex++;
-                        otherPlayer.SoundFileInfo = Files[PlayingIndex];
-                        otherPlayer.play();
-                        otherPlayer.Volume = 0;
-                    }
-
-                }
+                timerEventHandler();
             };
 
             timer.Start();
+        }
+
+        private void timerEventHandler() {
+            RaisePropertyChanged(nameof(PlayTime));
+            SoundPlayer player = eitherBeforePlayEnd;
+            if (player != null) {
+
+                // ボリュームの操作等の曲の切り替え中の動作をここに記述する
+                SoundPlayer otherPlayer = getOtherPlayer(player);
+
+                int volumeUpAmount = (SwitchingDuration != 0) ? Volume / SwitchingDuration : 0;
+                int volumeDownAmount = (SwitchingDuration != 0) ? Volume / SwitchingDuration : 0;
+
+                if (otherPlayer.Volume + volumeUpAmount < Volume) {
+                    otherPlayer.Volume += volumeUpAmount;
+                }
+                else {
+                    otherPlayer.Volume = Volume;
+                }
+
+                player.Volume -= Volume / switchingDuration / 2;
+
+                if (!otherPlayer.Playing) {
+                    PlayingIndex++;
+                    otherPlayer.SoundFileInfo = Files[PlayingIndex];
+                    otherPlayer.play();
+                    otherPlayer.Volume = 0;
+                }
+            }
         }
 
         /// <summary>

--- a/MusicPlayer/model/IPlayer.cs
+++ b/MusicPlayer/model/IPlayer.cs
@@ -5,7 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 
 namespace MusicPlayer.model {
-    interface IPlayer {
+    public interface IPlayer {
 
         event EventHandler mediaEnded;
         event EventHandler mediaStarted;

--- a/MusicPlayer/model/IPlayer.cs
+++ b/MusicPlayer/model/IPlayer.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MusicPlayer.model {
+    interface IPlayer {
+
+        event EventHandler mediaEnded;
+        event EventHandler mediaStarted;
+
+        void play();
+        void stop();
+        void pause();
+        bool Playing { get; }
+        bool Loading { get; }
+        String URL { get; set; }
+        int Volume { get; set; }
+        double Position { get; set; }
+        double Duration { get;}
+    }
+}

--- a/MusicPlayer/model/SoundPlayer.cs
+++ b/MusicPlayer/model/SoundPlayer.cs
@@ -20,7 +20,8 @@ namespace MusicPlayer.model {
 
     class SoundPlayer {
 
-        public SoundPlayer() {
+        public SoundPlayer(IPlayer player) {
+
             wmp.settings.volume = 100;
 
             wmp.PlayStateChange += (int NewState) => {

--- a/MusicPlayer/model/SoundPlayer.cs
+++ b/MusicPlayer/model/SoundPlayer.cs
@@ -14,11 +14,11 @@ using WMPLib;
 
 namespace MusicPlayer.model {
 
-    delegate void MediaEndedEventHandler(object sender);
-    delegate void MediaBeforeEndEventHandler(object sender);
-    delegate void PlayStartedEventHandler(object sender);
+    public delegate void MediaEndedEventHandler(object sender);
+    public delegate void MediaBeforeEndEventHandler(object sender);
+    public delegate void PlayStartedEventHandler(object sender);
 
-    class SoundPlayer {
+    public class SoundPlayer {
 
         public SoundPlayer(IPlayer player) {
 

--- a/MusicPlayer/model/SoundPlayer.cs
+++ b/MusicPlayer/model/SoundPlayer.cs
@@ -54,6 +54,7 @@ namespace MusicPlayer.model {
 
         public void play() {
             player.URL = soundFileInfo.FullName;
+            player.play();
             player.Position = FrontCut;
         }
 
@@ -97,6 +98,8 @@ namespace MusicPlayer.model {
             }
         }
 
+        public bool Loading => player.Loading;
+
         public double Duration { get; private set; } = 0;
 
         public Boolean Playing {
@@ -118,7 +121,7 @@ namespace MusicPlayer.model {
         /// </summary>
         public bool PassedBeforeEndPoint {
             get {
-                if (Duration == 0) {
+                if (Duration == 0 || SecondsOfBeforeEndNotice * 2 > Duration || !Playing) {
                     return false;
                 }
                 return (Position >= Duration - SecondsOfBeforeEndNotice - BackCut);

--- a/MusicPlayer/model/WMPWrapper.cs
+++ b/MusicPlayer/model/WMPWrapper.cs
@@ -62,7 +62,6 @@ namespace MusicPlayer.model {
             wmp.PlayStateChange += wmpPlayStateChangeEventHandler;
             URL = url;
             wmp.settings.volume = Volume;
-            System.Diagnostics.Debug.WriteLine("play!");
             wmp.controls.play();
         }
 

--- a/MusicPlayer/model/WMPWrapper.cs
+++ b/MusicPlayer/model/WMPWrapper.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using WMPLib;
+
+namespace MusicPlayer.model {
+    public class WMPWrapper : IPlayer {
+
+        private WindowsMediaPlayer wmp;
+
+        public WMPWrapper() {
+            wmp = new WindowsMediaPlayer();
+        }
+
+        public bool Playing => wmp.playState == WMPPlayState.wmppsPlaying;
+
+        public bool Loading => throw new NotImplementedException();
+
+        public string URL {
+            get => wmp.URL;
+            set => wmp.URL = value;
+        }
+
+        public int Volume {
+            get => wmp.settings.volume;
+            set => wmp.settings.volume = value;
+        }
+
+        public double Position {
+            get => wmp.controls.currentPosition;
+            set => wmp.controls.currentPosition = value;
+        }
+
+        public double Duration { get; }
+
+        public event EventHandler mediaEnded;
+        public event EventHandler mediaStarted;
+
+        public void pause() {
+            throw new NotImplementedException();
+        }
+
+        public void play() {
+            throw new NotImplementedException();
+        }
+
+        public void stop() {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/MusicPlayer/model/WMPWrapper.cs
+++ b/MusicPlayer/model/WMPWrapper.cs
@@ -54,7 +54,15 @@ namespace MusicPlayer.model {
         }
 
         public void play() {
-            wmp.URL = URL;
+            wmp.PlayStateChange -= wmpPlayStateChangeEventHandler;
+            string url = URL; // 一時退避
+            wmp.close();
+
+            wmp = new WindowsMediaPlayer();
+            wmp.PlayStateChange += wmpPlayStateChangeEventHandler;
+            URL = url;
+            wmp.settings.volume = Volume;
+            System.Diagnostics.Debug.WriteLine("play!");
             wmp.controls.play();
         }
 

--- a/MusicPlayer/model/WMPWrapper.cs
+++ b/MusicPlayer/model/WMPWrapper.cs
@@ -12,16 +12,7 @@ namespace MusicPlayer.model {
 
         public WMPWrapper() {
             wmp = new WindowsMediaPlayer();
-            wmp.PlayStateChange += (int NewState) => {
-                if(NewState == (int)WMPPlayState.wmppsPlaying) {
-                    mediaStarted?.Invoke(this, new EventArgs());
-                    Loading = false;
-                }
-
-                if(NewState == (int)WMPPlayState.wmppsMediaEnded) {
-                    mediaEnded?.Invoke(this, new EventArgs());
-                }
-            };
+            wmp.PlayStateChange += wmpPlayStateChangeEventHandler;
         }
 
         public bool Playing => wmp.playState == WMPPlayState.wmppsPlaying;
@@ -69,6 +60,17 @@ namespace MusicPlayer.model {
 
         public void stop() {
             wmp.controls.stop();
+        }
+
+        private void wmpPlayStateChangeEventHandler(int NewState) {
+            if(NewState == (int)WMPPlayState.wmppsPlaying) {
+                mediaStarted?.Invoke(this, new EventArgs());
+                Loading = false;
+            }
+
+            if(NewState == (int)WMPPlayState.wmppsMediaEnded) {
+                mediaEnded?.Invoke(this, new EventArgs());
+            }
         }
     }
 }

--- a/MusicPlayer/model/WMPWrapper.cs
+++ b/MusicPlayer/model/WMPWrapper.cs
@@ -12,15 +12,35 @@ namespace MusicPlayer.model {
 
         public WMPWrapper() {
             wmp = new WindowsMediaPlayer();
+            wmp.PlayStateChange += (int NewState) => {
+                if(NewState == (int)WMPPlayState.wmppsPlaying) {
+                    mediaStarted?.Invoke(this, new EventArgs());
+                    Loading = false;
+                }
+
+                if(NewState == (int)WMPPlayState.wmppsMediaEnded) {
+                    mediaEnded?.Invoke(this, new EventArgs());
+                }
+            };
         }
 
         public bool Playing => wmp.playState == WMPPlayState.wmppsPlaying;
 
-        public bool Loading => throw new NotImplementedException();
+        /// <summary>
+        /// URLをセットした時点で true になり、
+        /// wmp のステータスが WMPPlayState.wmppsPlaying に変化した時点で false になります。
+        /// </summary>
+        public bool Loading {
+            get;
+            private set;
+        } 
 
         public string URL {
             get => wmp.URL;
-            set => wmp.URL = value;
+            set {
+                wmp.URL = value;
+                Loading = true;
+            }
         }
 
         public int Volume {
@@ -39,15 +59,16 @@ namespace MusicPlayer.model {
         public event EventHandler mediaStarted;
 
         public void pause() {
-            throw new NotImplementedException();
+            wmp.controls.pause();
         }
 
         public void play() {
-            throw new NotImplementedException();
+            wmp.URL = URL;
+            wmp.controls.play();
         }
 
         public void stop() {
-            throw new NotImplementedException();
+            wmp.controls.stop();
         }
     }
 }

--- a/MusicPlayer/model/WMPWrapper.cs
+++ b/MusicPlayer/model/WMPWrapper.cs
@@ -53,7 +53,7 @@ namespace MusicPlayer.model {
             set => wmp.controls.currentPosition = value;
         }
 
-        public double Duration { get; }
+        public double Duration { get => wmp.currentMedia.duration; }
 
         public event EventHandler mediaEnded;
         public event EventHandler mediaStarted;

--- a/MusicPlayerTests3/MusicPlayerTests3.csproj
+++ b/MusicPlayerTests3/MusicPlayerTests3.csproj
@@ -1,0 +1,107 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{9280C61E-F581-4B6A-8EE4-D00F63D02F90}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>MusicPlayerTests3</RootNamespace>
+    <AssemblyName>MusicPlayerTests3</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.2.1.1\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.2.1.1\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+      </ItemGroup>
+    </When>
+    <Otherwise />
+  </Choose>
+  <ItemGroup>
+    <Compile Include="model\DoubleSoundPlayerTests.cs" />
+    <Compile Include="model\DummyWMP.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\MusicPlayer\MusicPlayer.csproj">
+      <Project>{D9ECFC5B-B6F9-4F87-A81E-3AEFFE5FF3FD}</Project>
+      <Name>MusicPlayer</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>このプロジェクトは、このコンピューター上にない NuGet パッケージを参照しています。それらのパッケージをダウンロードするには、[NuGet パッケージの復元] を使用します。詳細については、http://go.microsoft.com/fwlink/?LinkID=322105 を参照してください。見つからないファイルは {0} です。</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.targets'))" />
+  </Target>
+  <Import Project="..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.targets')" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/MusicPlayerTests3/MusicPlayerTests3.csproj
+++ b/MusicPlayerTests3/MusicPlayerTests3.csproj
@@ -45,7 +45,13 @@
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\MSTest.TestFramework.2.1.1\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
     </Reference>
+    <Reference Include="Prism, Version=7.2.0.1422, Culture=neutral, PublicKeyToken=40ee6c3a2184dc59, processorArchitecture=MSIL">
+      <HintPath>..\packages\Prism.Core.7.2.0.1422\lib\net45\Prism.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <Choose>
     <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
@@ -61,6 +67,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/MusicPlayerTests3/Properties/AssemblyInfo.cs
+++ b/MusicPlayerTests3/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// アセンブリに関する一般情報は以下の属性セットを使用して制御されます。 
+// アセンブリに関連付けられている情報を変更するには、
+// これらの属性値を変更してください。
+[assembly: AssemblyTitle("MusicPlayerTests3")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("MusicPlayerTests3")]
+[assembly: AssemblyCopyright("Copyright ©  2020")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// ComVisible を false に設定すると、その型はこのアセンブリ内で COM コンポーネントから
+// 参照不可能になります。COM からこのアセンブリ内の型にアクセスする場合は、 
+// その型の ComVisible 属性を true に設定してください。
+[assembly: ComVisible(false)]
+
+// このプロジェクトが COM に公開される場合、次の GUID が typelib の ID になります
+[assembly: Guid("9280c61e-f581-4b6a-8ee4-d00f63d02f90")]
+
+// アセンブリのバージョン情報は次の 4 つの値で構成されています:
+//
+//      メジャー バージョン
+//      マイナー バージョン
+//      ビルド番号
+//      Revision
+//
+// すべての値を指定するか、次を使用してビルド番号とリビジョン番号を既定に設定できます
+// 既定値にすることができます:
+//[アセンブリ: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/MusicPlayerTests3/app.config
+++ b/MusicPlayerTests3/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Windows.Interactivity" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.5.0.0" newVersion="4.5.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/MusicPlayerTests3/model/DoubleSoundPlayerTests.cs
+++ b/MusicPlayerTests3/model/DoubleSoundPlayerTests.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MusicPlayer.model;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MusicPlayer.model.Tests {
+    [TestClass()]
+    public class DoubleSoundPlayerTests {
+        [TestMethod()]
+        public void DoubleSoundPlayerTest() {
+        }
+    }
+}

--- a/MusicPlayerTests3/model/DoubleSoundPlayerTests.cs
+++ b/MusicPlayerTests3/model/DoubleSoundPlayerTests.cs
@@ -1,7 +1,9 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MusicPlayer.model;
+using MusicPlayerTests3.model;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -11,6 +13,102 @@ namespace MusicPlayer.model.Tests {
     public class DoubleSoundPlayerTests {
         [TestMethod()]
         public void DoubleSoundPlayerTest() {
+
+            var wmpA = new DummyWMP();
+            var wmpB = new DummyWMP();
+            wmpA.NextMediaDuration = 10;
+            wmpB.NextMediaDuration = 10;
+
+            var sp1 = new SoundPlayer(wmpA);
+            var sp2 = new SoundPlayer(wmpB);
+
+            DoubleSoundPlayer dsp = new DoubleSoundPlayer( sp1,sp2 );
+            dsp.SwitchingDuration = 10;
+            PrivateObject po = new PrivateObject(dsp);
+            po.Invoke("stopTimer");
+
+            Action<int> f = (int count) => {
+                for(var i = 0; i < count; i++) {
+                    wmpA.forward();
+                    wmpB.forward();
+
+                    if(i % 2 == 0) {
+                        // doubleSoundPlayer.timer の間隔が 450ms なので大体ループ２回に１回の頻度。
+                        po.Invoke("timerEventHandler");
+                    }
+
+                }
+            };
+
+
+            var files = new List<FileInfo>();
+            files.Add(new FileInfo("testFile1"));
+            files.Add(new FileInfo("testFile2"));
+            files.Add(new FileInfo("testFile3"));
+            files.Add(new FileInfo("testFile4"));
+            files.Add(new FileInfo("testFile5"));
+            files.Add(new FileInfo("testFile6"));
+            files.Add(new FileInfo("testFile7"));
+
+            foreach(FileInfo fi in files) {
+                fi.Create();
+            }
+
+            dsp.Files = files;
+            dsp.play();
+
+            Assert.IsTrue(sp1.Playing);
+            Assert.IsFalse(sp2.Playing);
+            Assert.IsTrue(wmpA.Loading,"wmpAのplay実行直後なのでロード中");
+
+
+            f(1);
+
+            Assert.IsFalse(wmpA.Loading,"forwardを一回実行したのでロードは終了している");
+
+            bool mediaEndedEventDispatched = false;
+            sp1.mediaEndedEvent += (sender) => { mediaEndedEventDispatched = true; };
+
+            f(50);
+            Assert.IsTrue(mediaEndedEventDispatched, "50回以上回したらメディアは終了するので、イベントが送出されているはず");
+
+            // 再生中のファイル名は次に移っている
+            Assert.AreEqual(sp1.SoundFileInfo.Name, "testFile2");
+            Assert.IsTrue(wmpA.Loading);
+            Assert.IsFalse(sp2.Playing);
+
+
+            f(1);
+            Assert.IsFalse(wmpA.Loading, "このタイミングではロードが完了している");
+
+            f(1);
+            wmpA.NextMediaDuration = 25;
+            wmpB.NextMediaDuration = 25;
+            
+            
+            f(50);
+            Assert.AreEqual(sp1.SoundFileInfo.Name, "testFile3");
+
+            // ループ76回(15秒強経過)で次の曲の再生が始まってほしい
+            f(76);
+            Assert.IsTrue(wmpA.Playing);
+            Assert.IsTrue(wmpB.Playing);
+
+            // 更に時間を進めて wmpA の曲が終了する
+            f(50);
+            Assert.IsFalse(wmpA.Playing);
+            Assert.IsTrue(wmpB.Playing);
+
+            f(50);
+            wmpA.NextMediaDuration = 10;
+            wmpB.NextMediaDuration = 10;
+
+            f(60);
+
+            Assert.IsTrue(wmpA.Playing);
+            Assert.IsFalse(wmpB.Playing);
+
+            f(60);
         }
     }
 }

--- a/MusicPlayerTests3/model/DummyWMP.cs
+++ b/MusicPlayerTests3/model/DummyWMP.cs
@@ -1,0 +1,73 @@
+﻿using MusicPlayer.model;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MusicPlayerTests3.model {
+    class DummyWMP : IPlayer {
+
+        private bool playing = false;
+        public bool Playing => playing;
+
+        private bool loading = false;
+        public bool Loading => loading;
+
+        private string url;
+        public string URL {
+            get => url;
+            set {
+                url = value;
+
+                // 実際のWMPの挙動として、
+                // 何故か URL をセットした時点で再生が開始されるため(?)、このようなコードがここに入る。
+                playing = true;
+                loading = true;
+            }
+        }
+
+        public int Volume { get; set; } = 100;
+        public double Position { get; set; }
+
+        public double NextMediaDuration { get; set; }
+        private double duration = 0;
+        public double Duration => duration;
+
+        public event EventHandler mediaEnded;
+        public event EventHandler mediaStarted;
+
+        public void pause() {
+            throw new NotImplementedException();
+        }
+
+        public void play() {
+            playing = true;
+            loading = true;
+        }
+
+        public void stop() {
+            playing = false;
+        }
+
+        public void forward() {
+            if (loading) {
+                loading = false;
+                duration = NextMediaDuration;
+                mediaStarted(this, new EventArgs());
+            }
+
+            if (!playing) {
+                return;
+            }
+
+            Position += 0.3;
+
+            if(Duration < Position) {
+                mediaEnded(this, new EventArgs());
+                Position = Duration;
+                playing = false;
+            }
+        }
+    }
+}

--- a/MusicPlayerTests3/model/DummyWMP.cs
+++ b/MusicPlayerTests3/model/DummyWMP.cs
@@ -24,6 +24,7 @@ namespace MusicPlayerTests3.model {
                 // 何故か URL をセットした時点で再生が開始されるため(?)、このようなコードがここに入る。
                 playing = true;
                 loading = true;
+                Position = 0;
             }
         }
 
@@ -61,12 +62,12 @@ namespace MusicPlayerTests3.model {
                 return;
             }
 
-            Position += 0.3;
+            Position += 0.2;
 
             if(Duration < Position) {
-                mediaEnded(this, new EventArgs());
                 Position = Duration;
                 playing = false;
+                mediaEnded(this, new EventArgs());
             }
         }
     }

--- a/MusicPlayerTests3/packages.config
+++ b/MusicPlayerTests3/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="MSTest.TestAdapter" version="2.1.1" targetFramework="net461" />
+  <package id="MSTest.TestFramework" version="2.1.1" targetFramework="net461" />
+</packages>

--- a/MusicPlayerTests3/packages.config
+++ b/MusicPlayerTests3/packages.config
@@ -2,4 +2,6 @@
 <packages>
   <package id="MSTest.TestAdapter" version="2.1.1" targetFramework="net461" />
   <package id="MSTest.TestFramework" version="2.1.1" targetFramework="net461" />
+  <package id="Prism.Core" version="7.2.0.1422" targetFramework="net461" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
- クラス追加 / プレイヤーの機能を表すI/F, I/Fを実装してWMPをラップするクラスを作成
- 機能追加 / WMPWrapper にI/Fに宣言された最低限必要な機能を実装
- 仕様変更 / SoundPlayer のコンストラクタ引数を変更。IPlayer を注入できるよう変更
- 仕様変更 / SoundPlayer の wmp を使用していた場所を IPlayer に置き換え
- 仕様変更 / DoubleSoundPlayer のコンストラクタから SoundPlayer を注入できるよう変更
- DoubleSoundPlayer のテストを作成するため、アクセスレベルを変更
- クラス追加 / DoubleSoundPlayer のテストクラス、WMPのダミークラスを追加
- 機能修正 / DummyWMPのイベント送出、プロパティ設定のタイミングを調整
- 機能追加 / SoundPlayerの再生終了の際、次のメディアを再生するハンドラを設定
- timer.Elapsed のハンドラ内の処理をメソッドに分離
- 機能追加 / Duration プロパティの実装を忘れていたので追加
- wmpにセットするイベントハンドラをメソッドとして分離
- 仕様変更 / play()の中身を変更。呼び出しごとにWMPインスタンスを再生成するよう実装
- 機能追加 / 正常に曲の連続再生ができるように実装
- 修正 / インデックスが範囲外に出ないよう修正

close #36
