### PR TITLE
アプリ起動時、前回終了時の状態に復元する機能の実装

### DIFF
--- a/MusicPlayer/App.config
+++ b/MusicPlayer/App.config
@@ -36,6 +36,9 @@
       <setting name="lastVisitedDirectoryPath" serializeAs="String">
         <value />
       </setting>
+      <setting name="lastPlayingFileName" serializeAs="String">
+        <value />
+      </setting>
     </MusicPlayer.Properties.Settings>
   </userSettings>
 </configuration>

--- a/MusicPlayer/App.config
+++ b/MusicPlayer/App.config
@@ -33,6 +33,9 @@
       <setting name="WindowHeight" serializeAs="String">
         <value>400</value>
       </setting>
+      <setting name="lastVisitedDirectoryPath" serializeAs="String">
+        <value />
+      </setting>
     </MusicPlayer.Properties.Settings>
   </userSettings>
 </configuration>

--- a/MusicPlayer/MainWindow.xaml
+++ b/MusicPlayer/MainWindow.xaml
@@ -91,6 +91,12 @@
                   Grid.Row="1"
                   Grid.Column="0" >
 
+            <TreeView.ItemContainerStyle>
+                <Style TargetType="TreeViewItem">
+                    <Setter Property="IsExpanded" Value="{Binding IsExpanded}"/>
+                </Style>
+            </TreeView.ItemContainerStyle>
+            
             <i:Interaction.Triggers>
                 <i:EventTrigger EventName="SelectedItemChanged">
                     <i:InvokeCommandAction Command="{Binding MediaFilesSettingCommand}"

--- a/MusicPlayer/MainWindow.xaml
+++ b/MusicPlayer/MainWindow.xaml
@@ -94,6 +94,7 @@
             <TreeView.ItemContainerStyle>
                 <Style TargetType="TreeViewItem">
                     <Setter Property="IsExpanded" Value="{Binding IsExpanded}"/>
+                    <Setter Property="IsSelected" Value="{Binding IsSelected}"/>
                 </Style>
             </TreeView.ItemContainerStyle>
             

--- a/MusicPlayer/MainWindowViewModel.cs
+++ b/MusicPlayer/MainWindowViewModel.cs
@@ -150,12 +150,6 @@ namespace MusicPlayer {
                 Properties.Settings.Default.DefaultBaseDirectoryPath : @"C:\";
             BaseDirectoryPath = path;
 
-            List<MediaDirectory> mdList = expandItemsTo(lastVisitedDirectoryPath);
-            System.Diagnostics.Debug.WriteLine(lastVisitedDirectoryPath);
-            if(mdList.Count != 0) {
-                Directory = mdList;
-            }
-
             doubleSoundPlayer = new DoubleSoundPlayer(
                 new SoundPlayer(new WMPWrapper()),
                 new SoundPlayer(new WMPWrapper())
@@ -219,6 +213,11 @@ namespace MusicPlayer {
                 },
                 () => { return doubleSoundPlayer.Playing; }
             ).ObservesProperty(() => Playing );
+
+            List<MediaDirectory> mdList = expandItemsTo(lastVisitedDirectoryPath);
+            if(mdList.Count != 0) {
+                Directory = mdList;
+            }
 
         }
 
@@ -287,6 +286,8 @@ namespace MusicPlayer {
             }
 
             md.IsExpanded = true;
+            md.IsSelected = true;
+            MediaFilesSettingCommand.Execute(md);
 
             return mdList;
         }

--- a/MusicPlayer/MainWindowViewModel.cs
+++ b/MusicPlayer/MainWindowViewModel.cs
@@ -237,5 +237,50 @@ namespace MusicPlayer {
                 () => MediaFiles.Count > 0
             )).ObservesProperty(() => MediaFiles);
         }
+
+        /// <summary>
+        /// 指定したパスに含まれるディレクトリが展開された状態のリストを生成します。
+        /// </summary>
+        /// <param name="path"></param>
+        /// <returns></returns>
+        private List<MediaDirectory> expandItemsTo(string path) {
+            if (!System.IO.Directory.Exists(path) || path == baseDirectoryPath) {
+                return new List<MediaDirectory>();
+            }
+
+            DirectoryInfo directoryInfo = new DirectoryInfo(path);
+            List<DirectoryInfo> directoryInfoList = new List<DirectoryInfo>();
+
+            while(directoryInfo != null){
+                directoryInfoList.Add(directoryInfo);
+                directoryInfo = directoryInfo.Parent;
+                if(directoryInfo.FullName == new DirectoryInfo(BaseDirectoryPath).Parent.FullName) {
+                    break;
+                }
+            }
+
+            // ルートに近いディレクトリほど奥に入っていて、ループ処理が逆順になってしまうため逆転させる。
+            directoryInfoList.Reverse();
+
+            MediaDirectory md = new MediaDirectory();
+            List<MediaDirectory> mdList = new List<MediaDirectory>();
+            mdList.Add(md);
+
+            for(var i = 0; i < directoryInfoList.Count; i++) {
+                md.FileInfo = new FileInfo(directoryInfoList[i].FullName);
+                md.GetChildsCommand.Execute();
+                md.IsExpanded = true;
+
+                if(directoryInfoList.Count <= i + 1) {
+                    break;
+                }
+
+                md = md.ChildDirectory.FirstOrDefault(m => m.FileInfo.FullName == directoryInfoList[i + 1].FullName);
+            }
+
+            md.IsExpanded = true;
+
+            return mdList;
+        }
     }
 }

--- a/MusicPlayer/MainWindowViewModel.cs
+++ b/MusicPlayer/MainWindowViewModel.cs
@@ -288,6 +288,11 @@ namespace MusicPlayer {
             md.IsExpanded = true;
             md.IsSelected = true;
             MediaFilesSettingCommand.Execute(md);
+            if(DoubleSoundPlayer.Files != null && DoubleSoundPlayer.Files.Count != 0) {
+                int sameFileNameIndex = DoubleSoundPlayer.Files.FindIndex(f => f.FullName == Properties.Settings.Default.lastPlayingFileName);
+                DoubleSoundPlayer.PlayingIndex = sameFileNameIndex;
+                DoubleSoundPlayer.updateSelectedFileName();
+            }
 
             return mdList;
         }

--- a/MusicPlayer/MainWindowViewModel.cs
+++ b/MusicPlayer/MainWindowViewModel.cs
@@ -144,9 +144,17 @@ namespace MusicPlayer {
 
         public MainWindowViewModel(IDialogService _dialogService) {
             dialogService = _dialogService;
+
+            string lastVisitedDirectoryPath = Properties.Settings.Default.lastVisitedDirectoryPath;
             var path = (new DirectoryInfo(Properties.Settings.Default.DefaultBaseDirectoryPath).Exists) ?
                 Properties.Settings.Default.DefaultBaseDirectoryPath : @"C:\";
             BaseDirectoryPath = path;
+
+            List<MediaDirectory> mdList = expandItemsTo(lastVisitedDirectoryPath);
+            System.Diagnostics.Debug.WriteLine(lastVisitedDirectoryPath);
+            if(mdList.Count != 0) {
+                Directory = mdList;
+            }
 
             doubleSoundPlayer = new DoubleSoundPlayer(
                 new SoundPlayer(new WMPWrapper()),

--- a/MusicPlayer/Properties/Settings.Designer.cs
+++ b/MusicPlayer/Properties/Settings.Designer.cs
@@ -94,5 +94,17 @@ namespace MusicPlayer.Properties {
                 this["lastVisitedDirectoryPath"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string lastPlayingFileName {
+            get {
+                return ((string)(this["lastPlayingFileName"]));
+            }
+            set {
+                this["lastPlayingFileName"] = value;
+            }
+        }
     }
 }

--- a/MusicPlayer/Properties/Settings.Designer.cs
+++ b/MusicPlayer/Properties/Settings.Designer.cs
@@ -82,5 +82,17 @@ namespace MusicPlayer.Properties {
                 this["WindowHeight"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string lastVisitedDirectoryPath {
+            get {
+                return ((string)(this["lastVisitedDirectoryPath"]));
+            }
+            set {
+                this["lastVisitedDirectoryPath"] = value;
+            }
+        }
     }
 }

--- a/MusicPlayer/Properties/Settings.settings
+++ b/MusicPlayer/Properties/Settings.settings
@@ -17,5 +17,8 @@
     <Setting Name="WindowHeight" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">400</Value>
     </Setting>
+    <Setting Name="lastVisitedDirectoryPath" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/MusicPlayer/Properties/Settings.settings
+++ b/MusicPlayer/Properties/Settings.settings
@@ -20,5 +20,8 @@
     <Setting Name="lastVisitedDirectoryPath" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
+    <Setting Name="lastPlayingFileName" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/MusicPlayer/model/DoubleSoundPlayer.cs
+++ b/MusicPlayer/model/DoubleSoundPlayer.cs
@@ -149,6 +149,10 @@ namespace MusicPlayer.model {
             CurrentPlayer.play();
         }
 
+        public void updateSelectedFileName() {
+            RaisePropertyChanged(nameof(PlayingFileName));
+        }
+
         private DelegateCommand<object> playFromIndexCommand;
         public DelegateCommand<object> PlayFromIndexCommand {
             get => playFromIndexCommand ?? (playFromIndexCommand = new DelegateCommand<object>(

--- a/MusicPlayer/model/MediaDirectory.cs
+++ b/MusicPlayer/model/MediaDirectory.cs
@@ -103,5 +103,11 @@ namespace MusicPlayer.model {
             get => isExpanded;
             set => SetProperty(ref isExpanded, value);
         }
+
+        private bool isSelected = false;
+        public bool IsSelected {
+            get => isSelected;
+            set => SetProperty(ref isSelected, value);
+        }
     }
 }

--- a/MusicPlayer/model/MediaDirectory.cs
+++ b/MusicPlayer/model/MediaDirectory.cs
@@ -53,16 +53,20 @@ namespace MusicPlayer.model {
         }
 
         private void getChild() {
-            var mediaDirectories = new List<MediaDirectory>();
+            if (!Directory.Exists(FileInfo.FullName)) {
+                return;
+            }
+
             string[] childFileNames = Directory.GetDirectories(FileInfo.FullName);
             string[] m3uFileNames = Directory.GetFiles(FileInfo.FullName, "*.m3u");
 
-           void addFiles(string[] fileOrDirectoryNames) {
-                foreach(string n in fileOrDirectoryNames) {
-                    var md = new MediaDirectory();
-                    md.FileInfo = new FileInfo(n);
-                    mediaDirectories.Add(md);
-                }
+            var mediaDirectories = new List<MediaDirectory>();
+            void addFiles(string[] fileOrDirectoryNames) {
+                 foreach(string n in fileOrDirectoryNames) {
+                     var md = new MediaDirectory();
+                     md.FileInfo = new FileInfo(n);
+                     mediaDirectories.Add(md);
+                 }
             }
 
             addFiles(childFileNames);

--- a/MusicPlayer/model/MediaDirectory.cs
+++ b/MusicPlayer/model/MediaDirectory.cs
@@ -91,5 +91,11 @@ namespace MusicPlayer.model {
         }
 
         public DelegateCommand GetChildsCommand { get; private set; }
+
+        private bool isExpanded = false;
+        public bool IsExpanded {
+            get => isExpanded;
+            set => SetProperty(ref isExpanded, value);
+        }
     }
 }

--- a/MusicPlayer/model/MediaDirectory.cs
+++ b/MusicPlayer/model/MediaDirectory.cs
@@ -73,6 +73,8 @@ namespace MusicPlayer.model {
             addFiles(m3uFileNames);
 
             ChildDirectory = mediaDirectories;
+            Properties.Settings.Default.lastVisitedDirectoryPath = FileInfo.FullName;
+            Properties.Settings.Default.Save();
         }
 
         /// <summary>

--- a/MusicPlayer/model/SoundPlayer.cs
+++ b/MusicPlayer/model/SoundPlayer.cs
@@ -52,6 +52,13 @@ namespace MusicPlayer.model {
             player.URL = soundFileInfo.FullName;
             player.play();
             player.Position = FrontCut;
+
+            /** ここで情報を記録するので、再生中のメディアが終了N秒前に入ってこのメソッドが呼び出されると、
+             *  最後に再生していたメディアが更新される。
+             *  最後の方まで再生した曲は、視聴を終えたとみなす。
+             */
+            Properties.Settings.Default.lastPlayingFileName = SoundFileInfo.FullName;
+            Properties.Settings.Default.Save();
         }
 
         public void pause() {


### PR DESCRIPTION
- プロパティ追加 / TreeViewItem が展開状態かを示すプロパティを追加してバインド
- 機能追加 / 指定パスまでのディレクトリを展開済みのツリーを取得するメソッドを追加
- 機能追加 / 最後に開いたディレクトリを、起動時に展開するよう実装
- 機能追加 / 最後に再生したメディアのパスを記録するよう変更
- 機能追加 / 最後に再生していたディレクトリを選択状態にしておくよう実装
- 機能追加 / 起動時、最後に再生した曲を選択した状態になるよう変更

close #70
