### PR TITLE
ディレクトリツリー関連のコードを MainWindowViewModel から分離

### DIFF
--- a/MusicPlayer/MainWindow.xaml
+++ b/MusicPlayer/MainWindow.xaml
@@ -177,7 +177,7 @@
             <StackPanel Orientation="Horizontal">
 
                 <Label Content="url >" />
-                <Label Content="{Binding SelectedDirectoryName, UpdateSourceTrigger=PropertyChanged}"
+                <Label Content="{Binding TreeViewModel.SelectedItem.FileInfo.FullName, UpdateSourceTrigger=PropertyChanged}"
                    Grid.Column="0"
                    >
             </Label>

--- a/MusicPlayer/MainWindow.xaml
+++ b/MusicPlayer/MainWindow.xaml
@@ -79,7 +79,7 @@
                        />
 
             <TextBox x:Name="baseDirectoryPathTextBox" 
-                     Text="{Binding BaseDirectoryPath, Mode=TwoWay}"
+                     Text="{Binding TreeViewModel.BaseDirectoryPath, Mode=TwoWay}"
                      FontSize="14"
                      />
 
@@ -87,7 +87,7 @@
         </StackPanel>
 
         <TreeView Name="directoryTree"
-                  ItemsSource="{Binding Directory}"
+                  ItemsSource="{Binding TreeViewModel.MediaDirectories}"
                   Grid.Row="1"
                   Grid.Column="0" >
 

--- a/MusicPlayer/MainWindow.xaml
+++ b/MusicPlayer/MainWindow.xaml
@@ -103,7 +103,7 @@
                     <i:InvokeCommandAction Command="{Binding MediaFilesSettingCommand}"
                                            CommandParameter="{Binding ElementName=directoryTree, Path=SelectedItem}"
                                            />
-                    <i:InvokeCommandAction Command="{Binding SelectedDirectorySettingCommand}"
+                    <i:InvokeCommandAction Command="{Binding TreeViewModel.SelectDirectoryCommand}"
                                            CommandParameter="{Binding ElementName=directoryTree, Path=SelectedItem}"
                                            />
                 </i:EventTrigger>

--- a/MusicPlayer/MainWindowViewModel.cs
+++ b/MusicPlayer/MainWindowViewModel.cs
@@ -60,7 +60,6 @@ namespace MusicPlayer {
             private set { mediaFilesSettingCommand = value; }
         }
 
-        public DelegateCommand<Object> SelectedDirectorySettingCommand { get; private set; }
         public String SelectedDirectoryName { get; private set; }
 
         public DelegateCommand PlayCommand { get; private set; }
@@ -141,14 +140,6 @@ namespace MusicPlayer {
                     }
 
                     doubleSoundPlayer.Files = mediaFiles;
-                },
-                (Object param) => { return true; }
-            );
-
-            SelectedDirectorySettingCommand = new DelegateCommand<object>(
-                (Object param) => {
-                    SelectedDirectoryName = ((MediaDirectory)param).FileInfo.FullName;
-                    RaisePropertyChanged(nameof(SelectedDirectoryName));
                 },
                 (Object param) => { return true; }
             );

--- a/MusicPlayer/MainWindowViewModel.cs
+++ b/MusicPlayer/MainWindowViewModel.cs
@@ -140,6 +140,8 @@ namespace MusicPlayer {
                 new SoundPlayer(new WMPWrapper())
             );
 
+            doubleSoundPlayer.CurrentDirectorySource = TreeViewModel;
+
             playerSetting = new PlayerSetting();
             playerSetting.DefaultBaseDirectoryPath = path;
             playerSetting.SwitchingDuration = Properties.Settings.Default.SwitchinDuration;

--- a/MusicPlayer/MainWindowViewModel.cs
+++ b/MusicPlayer/MainWindowViewModel.cs
@@ -83,8 +83,6 @@ namespace MusicPlayer {
             ));
         }
 
-        public String SelectedDirectoryName { get; private set; }
-
         public DelegateCommand PlayCommand { get; private set; }
 
         private IDialogService dialogService;

--- a/MusicPlayer/MainWindowViewModel.cs
+++ b/MusicPlayer/MainWindowViewModel.cs
@@ -102,6 +102,7 @@ namespace MusicPlayer {
                 Properties.Settings.Default.DefaultBaseDirectoryPath : @"C:\";
 
             TreeViewModel = new TreeViewModel(path);
+            TreeViewModel.expandItemsTo(lastVisitedDirectoryPath);
 
             doubleSoundPlayer = new DoubleSoundPlayer(
                 new SoundPlayer(new WMPWrapper()),

--- a/MusicPlayer/MainWindowViewModel.cs
+++ b/MusicPlayer/MainWindowViewModel.cs
@@ -14,7 +14,6 @@ using System.Threading.Tasks;
 namespace MusicPlayer {
     class MainWindowViewModel : BindableBase{
 
-        private List<MediaDirectory> directory = new List<MediaDirectory>();
         private DoubleSoundPlayer doubleSoundPlayer;
 
         public DoubleSoundPlayer DoubleSoundPlayer {

--- a/MusicPlayer/MainWindowViewModel.cs
+++ b/MusicPlayer/MainWindowViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using MusicPlayer.model;
+using MusicPlayer.viewModels;
 using Prism.Commands;
 using Prism.Mvvm;
 using Prism.Services.Dialogs;
@@ -18,6 +19,10 @@ namespace MusicPlayer {
 
         public DoubleSoundPlayer DoubleSoundPlayer {
             get { return doubleSoundPlayer; }
+        }
+
+        public TreeViewModel TreeViewModel {
+            get;
         }
 
         public List<MediaDirectory> Directory {
@@ -127,6 +132,8 @@ namespace MusicPlayer {
             var path = (new DirectoryInfo(Properties.Settings.Default.DefaultBaseDirectoryPath).Exists) ?
                 Properties.Settings.Default.DefaultBaseDirectoryPath : @"C:\";
             BaseDirectoryPath = path;
+
+            TreeViewModel = new TreeViewModel(path);
 
             doubleSoundPlayer = new DoubleSoundPlayer(
                 new SoundPlayer(new WMPWrapper()),

--- a/MusicPlayer/MusicPlayer.csproj
+++ b/MusicPlayer/MusicPlayer.csproj
@@ -89,6 +89,7 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </ApplicationDefinition>
+    <Compile Include="model\ICurrentDirectorySource.cs" />
     <Compile Include="model\IPlayer.cs" />
     <Compile Include="model\PlayerSetting.cs" />
     <Compile Include="model\WMPWrapper.cs" />

--- a/MusicPlayer/MusicPlayer.csproj
+++ b/MusicPlayer/MusicPlayer.csproj
@@ -96,6 +96,7 @@
       <DependentUpon>SettingWindow.xaml</DependentUpon>
     </Compile>
     <Compile Include="SettingWindowViewModel.cs" />
+    <Compile Include="viewModels\TreeViewModel.cs" />
     <Page Include="CustomDictionary.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>

--- a/MusicPlayer/model/DoubleSoundPlayer.cs
+++ b/MusicPlayer/model/DoubleSoundPlayer.cs
@@ -289,5 +289,7 @@ namespace MusicPlayer.model {
                 RaisePropertyChanged(nameof(Volume));
             }
         }
+
+        public ICurrentDirectorySource CurrentDirectorySource { private get; set; }
     }
 }

--- a/MusicPlayer/model/ICurrentDirectorySource.cs
+++ b/MusicPlayer/model/ICurrentDirectorySource.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MusicPlayer.model
+{
+    public interface ICurrentDirectorySource
+    {
+        DirectoryInfo CurrentDirectoryInfo { get; }
+    }
+}

--- a/MusicPlayer/viewModels/TreeViewModel.cs
+++ b/MusicPlayer/viewModels/TreeViewModel.cs
@@ -1,0 +1,37 @@
+﻿using MusicPlayer.model;
+using Prism.Mvvm;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MusicPlayer.viewModels
+{
+    class TreeViewModel :BindableBase
+    {
+        private string baseDirectoryPath = @"C:\";
+        public string BaseDirectoryPath {
+            get => baseDirectoryPath;
+            set => SetProperty(ref baseDirectoryPath, value);
+        }
+
+        private List<MediaDirectory> mediaDirectories = new List<MediaDirectory>();
+        public List<MediaDirectory> MediaDirectories {
+            get => mediaDirectories;
+            private set => SetProperty(ref mediaDirectories, value);
+        }
+
+        public object SelectedItem {
+            get; set;
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="baseDirectoryPath">このオブジェクトが始点とするディレクトリを入力します。
+        /// 無効な値が入力された場合は Cドライブのルートを設定します。</param>
+        public TreeViewModel (string baseDirectoryPath) {
+            BaseDirectoryPath = (System.IO.Directory.Exists(baseDirectoryPath)) ? baseDirectoryPath : @"C\";
+        }
+    }
+}

--- a/MusicPlayer/viewModels/TreeViewModel.cs
+++ b/MusicPlayer/viewModels/TreeViewModel.cs
@@ -14,7 +14,20 @@ namespace MusicPlayer.viewModels
         private string baseDirectoryPath = @"C:\";
         public string BaseDirectoryPath {
             get => baseDirectoryPath;
-            set => SetProperty(ref baseDirectoryPath, value);
+            set {
+                if (!Directory.Exists(value)) {
+                    return;
+                }
+
+                SetProperty(ref baseDirectoryPath, value);
+
+                // ディレクトリツリーの最上位の部分を生成する
+                var md = new MediaDirectory();
+                md.FileInfo = new FileInfo(value);
+                md.GetChildsCommand.Execute();
+
+                MediaDirectories = new List<MediaDirectory>(new MediaDirectory[] { md });
+            }
         }
 
         public DirectoryInfo CurrentDirectoryInfo => new DirectoryInfo(BaseDirectoryPath);

--- a/MusicPlayer/viewModels/TreeViewModel.cs
+++ b/MusicPlayer/viewModels/TreeViewModel.cs
@@ -70,9 +70,14 @@ namespace MusicPlayer.viewModels
         /// BaseDirectory から、指定したパスに含まれるディレクトリまでが展開された状態のリストを生成し、
         /// MediaDirectories にセットします。
         /// </summary>
-        /// <param name="path">パスが存在しない、または BaseDirectory と同一の場合は、動作を終了します。</param>
+        /// <param name="path">パスが存在しない、または BaseDirectory と同一の場合は、BaseDirectoryだけを展開して動作を終了します。</param>
         public void expandItemsTo(string path) {
             if (!Directory.Exists(path) || path == BaseDirectoryPath) {
+                SelectedItem = new MediaDirectory();
+                SelectedItem.FileInfo = new FileInfo(BaseDirectoryPath);
+                SelectedItem.GetChildsCommand.Execute();
+                SelectedItem.IsExpanded = true;
+                MediaDirectories = new List<MediaDirectory>(new MediaDirectory[] { SelectedItem });
                 return;
             }
 
@@ -108,6 +113,7 @@ namespace MusicPlayer.viewModels
 
             md.IsExpanded = true;
             md.IsSelected = true;
+            SelectedItem = md;
             MediaDirectories = mdList;
         }
 

--- a/MusicPlayer/viewModels/TreeViewModel.cs
+++ b/MusicPlayer/viewModels/TreeViewModel.cs
@@ -2,19 +2,22 @@
 using Prism.Mvvm;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
 namespace MusicPlayer.viewModels
 {
-    class TreeViewModel :BindableBase
+    class TreeViewModel : BindableBase, ICurrentDirectorySource
     {
         private string baseDirectoryPath = @"C:\";
         public string BaseDirectoryPath {
             get => baseDirectoryPath;
             set => SetProperty(ref baseDirectoryPath, value);
         }
+
+        public DirectoryInfo CurrentDirectoryInfo => new DirectoryInfo(BaseDirectoryPath);
 
         private List<MediaDirectory> mediaDirectories = new List<MediaDirectory>();
         public List<MediaDirectory> MediaDirectories {


### PR DESCRIPTION
- クラス追加 / ツリービュー用のビューモデルクラスを追加
- インターフェース追加 / 作業ディレクトリを取得可能なことを表すI/Fを追加
- コード移動 / baseDirectoryPath プロパティを TreeViewModel に移動
- 機能削除 / 不要になったプロパティ、メソッドを削除
- 機能追加 / expandItemsTo をTreeViewModel に移動し、これに必要なコマンド等を追加
- 機能削除 / 不要になったコマンドとプロパティを削除
- MediaFilesSettingCommand の動作を代入するコードをコンストラクタから分離
- 機能修正 / expandItemsTo() の異常系の動作を追加
- SelectedDirectoryName プロパティを移動
- 不要になったフィールド directory を削除

close #74
