### PR TITLE
特定の状況で停止ボタンを押すとクラッシュする件を修正

### DIFF
--- a/MusicPlayer/model/DoubleSoundPlayer.cs
+++ b/MusicPlayer/model/DoubleSoundPlayer.cs
@@ -148,6 +148,7 @@ namespace MusicPlayer.model {
         }
 
         public void play() {
+            PlayingIndex = 0;
             SelectedIndex = PlayingIndex;
             SelectedItem = Files[PlayingIndex];
             RaisePropertyChanged(nameof(PlayingFileName));
@@ -174,13 +175,15 @@ namespace MusicPlayer.model {
         }
 
         public void stop() {
-            PlayingIndex = 0;
+            PlayingIndex = int.MaxValue;
             CurrentPlayer.stop();
             getOtherPlayer(CurrentPlayer).stop();
 
             CurrentPlayer.Volume = this.Volume;
             getOtherPlayer(CurrentPlayer).Volume = this.Volume;
 
+            CurrentPlayer.setEmptyFileInfo();
+            updateSelectedFileName();
             mediaSwitching = false;
 
         }

--- a/MusicPlayer/model/DoubleSoundPlayer.cs
+++ b/MusicPlayer/model/DoubleSoundPlayer.cs
@@ -181,7 +181,6 @@ namespace MusicPlayer.model {
             CurrentPlayer.Volume = this.Volume;
             getOtherPlayer(CurrentPlayer).Volume = this.Volume;
 
-            CurrentPlayer.SoundFileInfo = Files[PlayingIndex].FileInfo;
             mediaSwitching = false;
 
         }

--- a/MusicPlayer/model/SoundPlayer.cs
+++ b/MusicPlayer/model/SoundPlayer.cs
@@ -160,5 +160,12 @@ namespace MusicPlayer.model {
         public int BackCut {
             get; set;
         }
+
+        /// <summary>
+        /// SoundFileInfo に対して、空の FileInfo を直接セットします。
+        /// </summary>
+        public void setEmptyFileInfo() {
+            soundFileInfo = new FileInfo("notExistEmptyFileInfo");
+        }
     }
 }


### PR DESCRIPTION
- バグ修正 / 特定の状況で停止ボタンを押した際にクラッシュする件を修正
- 仕様変更 / 停止ボタンを押した際、現在再生中の曲名を消去するよう挙動を変更

close #86
