### PR TITLE
曲の冒頭、終端カット機能の実装

### DIFF
--- a/MusicPlayer/Models/DoublePlayer.cs
+++ b/MusicPlayer/Models/DoublePlayer.cs
@@ -48,6 +48,8 @@
 
         public double Duration { get => duration; set => SetProperty(ref duration, value); }
 
+        public int FrontCut { get; set; }
+
         public ISoundProvider SoundProvider { get; private set; }
 
         public ObservableCollection<ISound> Sounds { get; }
@@ -74,6 +76,7 @@
 
                     if (nextSound.Duration >= SwitchingDuration * 1000 * 2.5)
                     {
+                        nextSound.FrontCut = FrontCut;
                         nextSound.Play();
                         nextSound.Volume = 0;
                         Switching = true;

--- a/MusicPlayer/Models/DoublePlayer.cs
+++ b/MusicPlayer/Models/DoublePlayer.cs
@@ -50,6 +50,8 @@
 
         public int FrontCut { get; set; }
 
+        public int BackCut { get; set; }
+
         public ISoundProvider SoundProvider { get; private set; }
 
         public ObservableCollection<ISound> Sounds { get; }
@@ -74,7 +76,7 @@
                     Sounds.Add(nextSound);
                     nextSound.MediaEnded += NextSound;
 
-                    if (nextSound.Duration >= SwitchingDuration * 1000 * 2.5)
+                    if (nextSound.Duration >= (SwitchingDuration * 1000 * 2.5) + (BackCut * 1000))
                     {
                         nextSound.FrontCut = FrontCut;
                         nextSound.Play();

--- a/MusicPlayer/Models/ISound.cs
+++ b/MusicPlayer/Models/ISound.cs
@@ -22,6 +22,10 @@
 
         double Duration { get; }
 
+        int FrontCut { get; set; }
+
+        int BackCut { get; set; }
+
         void Load();
 
         void Play();

--- a/MusicPlayer/Models/NAudioSound.cs
+++ b/MusicPlayer/Models/NAudioSound.cs
@@ -68,6 +68,7 @@
             {
                 reader = new AudioFileReader(URL);
                 reader.Position = 0;
+                reader.CurrentTime = new TimeSpan(0, 0, FrontCut);
 
                 Duration = reader.TotalTime.TotalMilliseconds;
                 waveOut = new WaveOutEvent();

--- a/MusicPlayer/Models/NAudioSound.cs
+++ b/MusicPlayer/Models/NAudioSound.cs
@@ -42,6 +42,10 @@
 
         public double Duration { get => duration; private set => SetProperty(ref duration, value); }
 
+        public int FrontCut { get; set; }
+
+        public int BackCut { get; set; }
+
         public void Load()
         {
             if (!string.IsNullOrEmpty(URL))

--- a/MusicPlayer/viewModels/MainWindowViewModel.cs
+++ b/MusicPlayer/viewModels/MainWindowViewModel.cs
@@ -47,6 +47,9 @@
             playerSetting.BackCut = Properties.Settings.Default.BackCut;
             playerSetting.FrontCut = Properties.Settings.Default.FrontCut;
 
+            DoublePlayer.FrontCut = playerSetting.FrontCut;
+            DoublePlayer.BackCut = playerSetting.BackCut;
+
             DoublePlayer.SwitchingDuration = playerSetting.SwitchingDuration;
 
             PlayCommand = new DelegateCommand(
@@ -161,6 +164,9 @@
                         Properties.Settings.Default.FrontCut = pSettings.FrontCut;
                         Properties.Settings.Default.BackCut = pSettings.BackCut;
                         Properties.Settings.Default.Save();
+
+                        DoublePlayer.FrontCut = pSettings.FrontCut;
+                        DoublePlayer.BackCut = pSettings.BackCut;
                     }
                 });
             }));

--- a/MusicPlayerTests3/Models/DummySound.cs
+++ b/MusicPlayerTests3/Models/DummySound.cs
@@ -53,6 +53,10 @@
 
         public string Name => throw new NotImplementedException();
 
+        public int FrontCut { get; set; }
+
+        public int BackCut { get; set; }
+
         public void Pause()
         {
             throw new NotImplementedException();


### PR DESCRIPTION
- add / ISound に FrontCut, BackCut プロパティを追加
- add / サウンドの再生時、先頭部を指定秒カットする機能を実装
- add / クロスフェードの開始が BackCut 分早くなるよう実装
- add / 設定画面の Front, BackCut をプレイヤーに反映するコードを追加

close #99
