### PR TITLE
fix / 曲の切り替わり時の音量の変更が完全に行われるよう修正

### DIFF
--- a/MusicPlayer/Models/DoublePlayer.cs
+++ b/MusicPlayer/Models/DoublePlayer.cs
@@ -157,9 +157,9 @@
             }
 
             int timerExecuteCountPerSec = 4;
-            int amount = Volume / Math.Max(SwitchingDuration - 2, 1) / timerExecuteCountPerSec;
-            Sounds.First().Volume -= amount;
-            Sounds.Last().Volume += (int)(amount * 1.5);
+            decimal amount = Math.Ceiling((decimal)Volume / Math.Max(SwitchingDuration - 2, 1) / timerExecuteCountPerSec);
+            Sounds.First().Volume -= (int)amount;
+            Sounds.Last().Volume += (int)(amount * 1.5m);
         }
     }
 }

--- a/MusicPlayerTests3/Models/DoublePlayerTests.cs
+++ b/MusicPlayerTests3/Models/DoublePlayerTests.cs
@@ -55,11 +55,11 @@
 
             forward(1);
             Assert.IsTrue(provider.Sounds[0].Volume < 100);
-            Assert.IsTrue(provider.Sounds[1].Volume > 0 && provider.Sounds[1].Volume < 20);
+            Assert.IsTrue(provider.Sounds[1].Volume > 0 && provider.Sounds[1].Volume < 30);
 
             forward(1);
             Assert.IsTrue(provider.Sounds[0].Volume < 100);
-            Assert.IsTrue(provider.Sounds[1].Volume > 0 && provider.Sounds[1].Volume < 40);
+            Assert.IsTrue(provider.Sounds[1].Volume > 0 && provider.Sounds[1].Volume < 50);
 
             forward(8); // 30sec
             Assert.IsFalse(player.Switching, "クロスフェード終了");
@@ -74,11 +74,11 @@
 
             forward(1);
             Assert.IsTrue(provider.Sounds[1].Volume < 100);
-            Assert.IsTrue(provider.Sounds[2].Volume > 0 && provider.Sounds[2].Volume < 20);
+            Assert.IsTrue(provider.Sounds[2].Volume > 0 && provider.Sounds[2].Volume < 30);
 
             forward(1);
             Assert.IsTrue(provider.Sounds[1].Volume < 100);
-            Assert.IsTrue(provider.Sounds[2].Volume > 0 && provider.Sounds[2].Volume < 40);
+            Assert.IsTrue(provider.Sounds[2].Volume > 0 && provider.Sounds[2].Volume < 50);
 
             forward(8); // 50sec
             Assert.IsFalse(player.Switching, "クロスフェード終了");
@@ -93,11 +93,11 @@
 
             forward(1);
             Assert.IsTrue(provider.Sounds[2].Volume < 100);
-            Assert.IsTrue(provider.Sounds[3].Volume > 0 && provider.Sounds[3].Volume < 20);
+            Assert.IsTrue(provider.Sounds[3].Volume > 0 && provider.Sounds[3].Volume < 30);
 
             forward(1);
             Assert.IsTrue(provider.Sounds[2].Volume < 100);
-            Assert.IsTrue(provider.Sounds[3].Volume > 0 && provider.Sounds[3].Volume < 40);
+            Assert.IsTrue(provider.Sounds[3].Volume > 0 && provider.Sounds[3].Volume < 50);
 
             forward(8); // 70sec
             Assert.IsFalse(player.Switching, "クロスフェード終了");


### PR DESCRIPTION
今まで、音量の変更が不完全な形で終わってしまっていたでそれを修正。
内部の計算式を修正したのに伴い、テストも変更

close #101
